### PR TITLE
fix: Vodafone UK MT SMS over WiFi Calling

### DIFF
--- a/internal/vowifi/ims/provider.go
+++ b/internal/vowifi/ims/provider.go
@@ -946,7 +946,7 @@ func (session *Session) buildRegister(
 	}
 	o2Germany := usesO2GermanyIMSProfile(session.request.Identity)
 	supported := "path, gruu"
-	allow := "REGISTER, INVITE, ACK, CANCEL, BYE, OPTIONS"
+	allow := "REGISTER, INVITE, ACK, CANCEL, BYE, OPTIONS, MESSAGE, SUBSCRIBE, NOTIFY"
 	if o2Germany {
 		// Match the complete IMS capability set used by the previously working
 		// VoHive client. O2 validates more of the initial UE security profile
@@ -984,6 +984,12 @@ func (session *Session) buildRegister(
 			`P-Visited-Network-ID: "one.att.net"`,
 			"P-Access-Network-Info: IEEE-802.11;i-wlan-node-id=000000000000;network-provided",
 			"Cellular-Network-Info: 3GPP-E-UTRAN-FDD;utran-cell-id-3gpp=3102800000000;cell-info-age=0",
+			"Accept-Contact: *;+g.3gpp.smsip",
+			`Accept-Contact: *;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel"`,
+		)
+	} else {
+		lines = append(lines,
+			"P-Access-Network-Info: IEEE-802.11;i-wlan-node-id=000000000000;network-provided",
 			"Accept-Contact: *;+g.3gpp.smsip",
 			`Accept-Contact: *;+g.3gpp.icsi-ref="urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel"`,
 		)

--- a/internal/vowifi/ims/security.go
+++ b/internal/vowifi/ims/security.go
@@ -534,25 +534,7 @@ func buildXFRMInstallPlan(config IPSecSAConfig) ([]xfrmOperation, error) {
 		for _, protocol := range flow.protocols {
 			operations = append(operations, xfrmOperation{
 				description: flow.description + " " + protocol + " policy",
-				arguments: []string{
-					flow.family,
-					"xfrm", "policy", "add",
-					"src", flow.sourcePrefix,
-					"dst", flow.destinationPrefix,
-					"proto", protocol,
-					"sport", strconv.Itoa(flow.sourcePort),
-					"dport", strconv.Itoa(flow.destinationPort),
-					"dir", flow.direction,
-					"priority", "100",
-					"tmpl",
-					"src", flow.templateSource.String(),
-					"dst", flow.templateDestination.String(),
-					"proto", "esp",
-					"spi", fmt.Sprintf("0x%08x", flow.spi),
-					"reqid", strconv.FormatUint(uint64(flow.reqid), 10),
-					"mode", "transport",
-					"level", "required",
-				},
+				arguments: xfrmPolicyArgs(flow, protocol, false),
 			})
 		}
 	}
@@ -568,16 +550,7 @@ func buildXFRMCleanupPlan(config IPSecSAConfig) []xfrmOperation {
 			protocol := flow.protocols[protocolIndex]
 			operations = append(operations, xfrmOperation{
 				description: "delete " + flow.description + " " + protocol + " policy",
-				arguments: []string{
-					flow.family,
-					"xfrm", "policy", "delete",
-					"src", flow.sourcePrefix,
-					"dst", flow.destinationPrefix,
-					"proto", protocol,
-					"sport", strconv.Itoa(flow.sourcePort),
-					"dport", strconv.Itoa(flow.destinationPort),
-					"dir", flow.direction,
-				},
+				arguments: xfrmPolicyArgs(flow, protocol, true),
 			})
 		}
 	}
@@ -604,6 +577,45 @@ func buildXFRMCleanupPlan(config IPSecSAConfig) []xfrmOperation {
 		})
 	}
 	return operations
+}
+
+
+func xfrmPolicyArgs(flow xfrmFlow, protocol string, delete bool) []string {
+	args := []string{
+		flow.family,
+		"xfrm", "policy",
+	}
+	if delete {
+		args = append(args, "delete")
+	} else {
+		args = append(args, "add")
+	}
+	args = append(args,
+		"src", flow.sourcePrefix,
+		"dst", flow.destinationPrefix,
+		"proto", protocol,
+	)
+	if flow.sourcePort > 0 {
+		args = append(args, "sport", strconv.Itoa(flow.sourcePort))
+	}
+	if flow.destinationPort > 0 {
+		args = append(args, "dport", strconv.Itoa(flow.destinationPort))
+	}
+	args = append(args, "dir", flow.direction)
+	if delete {
+		return args
+	}
+	return append(args,
+		"priority", "100",
+		"tmpl",
+		"src", flow.templateSource.String(),
+		"dst", flow.templateDestination.String(),
+		"proto", "esp",
+		"spi", fmt.Sprintf("0x%08x", flow.spi),
+		"reqid", strconv.FormatUint(uint64(flow.reqid), 10),
+		"mode", "transport",
+		"level", "required",
+	)
 }
 
 type xfrmFlow struct {
@@ -650,7 +662,7 @@ func xfrmFlows(config IPSecSAConfig) []xfrmFlow {
 		{
 			description: "P-CSCF-client to UE-server", family: family,
 			sourcePrefix: remotePrefix, destinationPrefix: localPrefix,
-			sourcePort: config.PCSCFClientPort, destinationPort: config.UEServerPort,
+			sourcePort: 0, destinationPort: config.UEServerPort,
 			direction: "in", templateSource: config.RemoteIP, templateDestination: config.LocalIP,
 			spi: config.UEServerSPI, reqid: serverPairReqID(config),
 			protocols: []string{"tcp", "udp"},
@@ -916,9 +928,7 @@ func (session *Session) validProtectedUDPSource(remote *net.UDPAddr) bool {
 		return false
 	}
 	expectedIP := addressIP(session.conn.RemoteAddr())
-	return expectedIP != nil &&
-		expectedIP.Equal(remote.IP) &&
-		remote.Port == session.securityAgreement.selected.portClient
+	return expectedIP != nil && expectedIP.Equal(remote.IP)
 }
 
 func (session *Session) effectiveSecurityMode() string {

--- a/internal/vowifi/ims/sms_runtime.go
+++ b/internal/vowifi/ims/sms_runtime.go
@@ -91,11 +91,14 @@ func (session *Session) startRuntimeReceivers() error {
 
 	session.receiveDone.Add(1)
 	go session.readMainConnection()
-	if session.securityActive && session.transport == "tcp" && session.protectedTCP != nil {
+	// Vodafone UK (and others) deliver MT SMS as SIP MESSAGE to the
+	// ipsec-3gpp UE server port over UDP even when REGISTER used TCP.
+	// Always read both sockets when they were reserved.
+	if session.securityActive && session.protectedTCP != nil {
 		session.receiveDone.Add(1)
 		go session.acceptProtectedTCP()
 	}
-	if session.securityActive && session.transport == "udp" && session.protectedUDP != nil {
+	if session.securityActive && session.protectedUDP != nil {
 		session.receiveDone.Add(1)
 		go session.readProtectedUDP()
 	}
@@ -140,6 +143,8 @@ func (session *Session) acceptProtectedTCP() {
 			return
 		}
 		if !session.validProtectedTCPSource(connection.RemoteAddr()) {
+			session.logInboundSMS(slog.LevelWarn, "IMS inbound TCP rejected", nil,
+				"stage", "source_filter", "remote", connection.RemoteAddr().String())
 			_ = connection.Close()
 			continue
 		}
@@ -186,6 +191,8 @@ func (session *Session) readProtectedUDP() {
 			return
 		}
 		if !session.validProtectedUDPSource(remote) {
+			session.logInboundSMS(slog.LevelWarn, "IMS inbound UDP rejected", nil,
+				"stage", "source_filter", "remote", remote.String(), "packet_bytes", count)
 			continue
 		}
 		packet, err := parseSIPPacket(buffer[:count])
@@ -208,8 +215,9 @@ func (session *Session) validProtectedTCPSource(address net.Addr) bool {
 		return false
 	}
 	expected := addressIP(session.conn.RemoteAddr())
-	return expected != nil && expected.Equal(remote.IP) &&
-		remote.Port == session.securityAgreement.selected.portClient
+	// Require P-CSCF IP. Do not require port-c (50601): some cores originate
+	// MESSAGE from an ephemeral port on the same P-CSCF.
+	return expected != nil && expected.Equal(remote.IP)
 }
 
 func (session *Session) dispatchPacket(packet sipPacket, respond func([]byte) error) {


### PR DESCRIPTION
## Environment
- Official VoCat **v0.2.2 / v0.2.3** (`vocat-linux-arm64`)
- OpenWrt/LibWrt aarch64, Quectel EC25, VOXI / Vodafone UK PLMN **234/15**
- ePDG + IMS REGISTER succeed (`sms_ready`, `smsip.ready=true`)
- MO SMS works (SIP 202). Voice MO works.
- **MT SMS over IMS does not appear in the inbox** until three local fixes are applied.

Same SIM + same module receives MT SMS fine with VoHive. This is a VoCat + OpenWrt interaction, not the carrier blocking the subscriber.

## What we captured
On a live `sms_ready` session, sending an SMS produces inbound ipsec-3gpp ESP on the UE-server SA (tens of packets, ~14–22 KiB, SIP MESSAGE sized). There is **no** TCP/UDP conntrack to the Contact port and **no** `IMS inbound SMS MESSAGE received` log until the three issues below are fixed.

After the fixes, Vodafone delivered four IMS messages in one burst (including previously queued ones) with:

```
IMS inbound SMS MESSAGE received  content_type=application/vnd.3gpp.sms
IMS inbound SMS processed         payload_source=application/vnd.3gpp.sms
```

P-CSCF connected `10.x.x.x:50601 -> <UE>:port-s` once the path was open.

## Three bugs (still present on v0.2.3 master)

### 1. UDP inbound socket is reserved but never read when REGISTER used TCP
`startRuntimeReceivers()` only starts `readProtectedUDP()` when `session.transport == "udp"`. Vodafone UK REGISTERs over TCP, but still delivers MT SMS as SIP MESSAGE to the ipsec-3gpp **UE server port** (UDP and/or a new TCP). VoCat already `ListenUDP`s that port; it just never reads it.

VoHive starts both the TCP listener **and** the UDP receiver in ipsec-3gpp mode. That is the working reference.

**Fix:** if `protectedTCP` / `protectedUDP` were reserved, start both receivers regardless of REGISTER transport. Log rejected sources instead of silently `Close()`.

### 2. REGISTER `Allow` omits `MESSAGE` for Vodafone UK
Default Allow is `REGISTER, INVITE, ACK, CANCEL, BYE, OPTIONS`. `MESSAGE` is only added for the O2 Germany profile. `Accept-Contact: *;+g.3gpp.smsip` is only added for AT&T.

Contact still has `+g.3gpp.smsip`, so the UI shows `sms_ready` and MO SMS works. The network does not reliably treat the UE as an MT SMS endpoint.

**Fix:** include `MESSAGE` (and smsip Accept-Contact) for all carriers, including `vodafone-uk`.

### 3. ipsec-3gpp XFRM inbound policy requires P-CSCF `port-c` (50601)
`xfrmFlows()` installs:

`P-CSCF:50601 -> UE:port-s` for tcp/udp

Vodafone often originates the MESSAGE from another source port on the same P-CSCF. The SA SPI still matches (byte counters go up) but the **policy** drops the inner packet, so userspace never sees it.

**Fix:** omit `sport` on the inbound P-CSCF-client → UE-server policies (still pin src IP + dport=UE server port + SPI/reqid).

Userspace `validProtectedTCPSource` / `validProtectedUDPSource` should likewise require P-CSCF IP, not `port-c`.

## OpenWrt/fw4 (not a VoCat code bug, but blocks all of the above)
Userspace dataplane creates `vocatf*`. fw4 `input` only jumps `br-lan` / `wan` / `vocatwg`, then `handle_reject`. Outbound REGISTER is `ct established` so it works. **New inbound MESSAGE to `vocatf*` is rejected.**

Please document this, or have the TUN bring-up path install an input accept for `vocatf*` (device wildcard `vocatf+` in a dedicated zone).

Local workaround that unblocked us:

```
nft insert rule inet fw4 input iifname "vocatfXXXX" accept
```

plus a `firewall` zone `input=ACCEPT` with `device='vocatf+'`.

## Suggested patch (verified on 234/15)
1. Always run `acceptProtectedTCP` + `readProtectedUDP` when those sockets exist.
2. Default Allow includes `MESSAGE`; add smsip Accept-Contact for non-AT&T.
3. Inbound UE-server XFRM policy: no `sport` (any P-CSCF source port).
4. Docs / installer: OpenWrt must accept input on `vocatf*`.

Happy to open a PR with those changes. Tested live: after 1–3, MT SMS from `ipsmbe1mc05.vodafone.com` is processed and stored with `source=ims`.
