### PR TITLE
test: align IMS registration expectations

### DIFF
--- a/internal/vowifi/ims/provider_test.go
+++ b/internal/vowifi/ims/provider_test.go
@@ -375,7 +375,6 @@ func serveRegistration(listener *net.UDPConn, nonce string, confirmSMS bool) err
 			return fmt.Errorf("unexpected start line %q", startLine)
 		}
 		for _, forbidden := range []string{
-			"p-access-network-info",
 			"p-visited-network-id",
 			"p-preferred-identity",
 		} {
@@ -386,6 +385,13 @@ func serveRegistration(listener *net.UDPConn, nonce string, confirmSMS bool) err
 					headers[forbidden],
 				)
 			}
+		}
+		if headers["p-access-network-info"] != "IEEE-802.11;i-wlan-node-id=000000000000;network-provided" {
+			return fmt.Errorf("REGISTER P-Access-Network-Info = %q", headers["p-access-network-info"])
+		}
+		if !strings.Contains(headers["allow"], "MESSAGE") ||
+			!strings.Contains(string(packet[:count]), "Accept-Contact: *;+g.3gpp.smsip") {
+			return fmt.Errorf("REGISTER omitted SMS-over-IMS capability: Allow=%q", headers["allow"])
 		}
 		if step == 0 {
 			if headers["authorization"] != "" {

--- a/internal/vowifi/ims/security_provider_test.go
+++ b/internal/vowifi/ims/security_provider_test.go
@@ -531,8 +531,8 @@ func serveProtectedRegistrar(
 		return result, fmt.Errorf("protected Contact = %q", headers["contact"])
 	}
 	if strings.Contains(strings.ToUpper(startLine), "MESSAGE") ||
-		strings.Contains(strings.ToUpper(headers["allow"]), "MESSAGE") {
-		return result, errors.New("registration transaction advertised or sent MESSAGE")
+		!strings.Contains(strings.ToUpper(headers["allow"]), "MESSAGE") {
+		return result, errors.New("registration transaction did not advertise MESSAGE correctly")
 	}
 
 	if _, err := protectedConnection.Write(testResponse(

--- a/internal/vowifi/ims/security_test.go
+++ b/internal/vowifi/ims/security_test.go
@@ -287,14 +287,18 @@ func TestXFRMPlanContainsFourStatesAndProtocolSpecificPolicies(t *testing.T) {
 		"tcp 40666 50600 out": false,
 		"udp 40666 50600 out": false,
 		"tcp 50600 40666 in":  false,
-		"tcp 50601 55610 in":  false,
-		"udp 50601 55610 in":  false,
+		"tcp * 55610 in":      false,
+		"udp * 55610 in":      false,
 		"tcp 55610 50601 out": false,
 	}
 	for _, operation := range install[4:] {
+		sourcePort := "*"
+		if value, ok := optionalArgumentAfter(operation.arguments, "sport"); ok {
+			sourcePort = value
+		}
 		key := strings.Join([]string{
 			argumentAfter(t, operation.arguments, "proto"),
-			argumentAfter(t, operation.arguments, "sport"),
+			sourcePort,
 			argumentAfter(t, operation.arguments, "dport"),
 			argumentAfter(t, operation.arguments, "dir"),
 		}, " ")
@@ -395,6 +399,15 @@ func argumentAfter(t *testing.T, arguments []string, name string) string {
 	}
 	t.Fatalf("arguments %v omit %q", arguments, name)
 	return ""
+}
+
+func optionalArgumentAfter(arguments []string, name string) (string, bool) {
+	for index := 0; index+1 < len(arguments); index++ {
+		if arguments[index] == name {
+			return arguments[index+1], true
+		}
+	}
+	return "", false
 }
 
 func containsArguments(arguments []string, sequence ...string) bool {


### PR DESCRIPTION
## Summary

PR #39 intentionally changed generic REGISTER requests to advertise SMS-over-IMS and relaxed inbound UE-server XFRM source-port matching. Three existing tests still enforced the previous behavior, causing the current `master` IMS suite to fail with two registration timeouts, one TCP EOF, and one missing-`sport` assertion.

This change updates only those test contracts:

- require the default PANI, `Allow: MESSAGE`, and `Accept-Contact: +g.3gpp.smsip`
- allow the authenticated protected REGISTER to advertise MESSAGE
- represent the intentionally wildcard inbound P-CSCF source port as `*` in XFRM policy assertions

## Validation

- `go test ./internal/vowifi/ims -count=1`
- `go vet ./internal/vowifi/ims`

No runtime behavior changes.
