### PR TITLE
fix: ignore non-voice CLCC records in call monitor

### DIFF
--- a/internal/server/call_notifications.go
+++ b/internal/server/call_notifications.go
@@ -325,11 +325,7 @@ func (s *Server) pollCellularCalls(ctx context.Context) {
 		}
 		calls := parseCLCC(response)
 		for _, call := range calls {
-			direction, _ := call["direction"].(int)
-			state, _ := call["state"].(int)
-			// direction 1 = incoming (Mobile Terminated)
-			// state 4 = incoming/ringing, 5 = waiting, 0 = active, 3 = alerting
-			if direction == 1 && (state == 4 || state == 5 || state == 0 || state == 3) {
+			if isIncomingVoiceCLCC(call) {
 				caller, _ := call["number"].(string)
 				if caller == "" {
 					caller = "未知号码"
@@ -350,4 +346,14 @@ func (s *Server) pollCellularCalls(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func isIncomingVoiceCLCC(call map[string]any) bool {
+	direction, _ := call["direction"].(int)
+	state, _ := call["state"].(int)
+	mode, _ := call["mode"].(int)
+	// direction 1 = incoming (Mobile Terminated)
+	// mode 0 = voice; some modems also expose packet-data sessions as CLCC mode 1
+	// state 4 = incoming/ringing, 5 = waiting, 0 = active, 3 = alerting
+	return direction == 1 && mode == 0 && (state == 4 || state == 5 || state == 0 || state == 3)
 }

--- a/internal/server/call_notifications_test.go
+++ b/internal/server/call_notifications_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"vocat/internal/modem"
 )
 
 func TestIncomingCallNotificationTextFormatting(t *testing.T) {
@@ -58,6 +60,56 @@ func TestIncomingCallDeduplication(t *testing.T) {
 	// Call after window should be allowed
 	if shouldSuppressDuplicateCall(key, now.Add(70*time.Second), time.Minute) {
 		t.Fatal("call after window was suppressed")
+	}
+}
+
+func TestIncomingVoiceCLCCIgnoresDataSessions(t *testing.T) {
+	tests := []struct {
+		name string
+		call map[string]any
+		want bool
+	}{
+		{
+			name: "incoming voice ringing",
+			call: map[string]any{"direction": 1, "state": 4, "mode": 0},
+			want: true,
+		},
+		{
+			name: "incoming voice active",
+			call: map[string]any{"direction": 1, "state": 0, "mode": 0},
+			want: true,
+		},
+		{
+			name: "incoming packet data active",
+			call: map[string]any{"direction": 1, "state": 0, "mode": 1},
+			want: false,
+		},
+		{
+			name: "outgoing voice alerting",
+			call: map[string]any{"direction": 0, "state": 3, "mode": 0},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isIncomingVoiceCLCC(test.call); got != test.want {
+				t.Fatalf("isIncomingVoiceCLCC() = %v, want %v", got, test.want)
+			}
+		})
+	}
+
+	// EC20/EC25 firmware may expose an active packet-data session in CLCC.
+	// It must not be treated as an incoming voice call.
+	dataCalls := parseCLCC(modem.Response{
+		Lines: []string{`+CLCC: 1,1,0,1,0,"",128`},
+		Final: "OK",
+	})
+	if len(dataCalls) != 1 {
+		t.Fatalf("parseCLCC() returned %d data calls, want 1", len(dataCalls))
+	}
+	if isIncomingVoiceCLCC(dataCalls[0]) {
+		t.Fatal("active packet-data CLCC record was treated as an incoming voice call")
 	}
 }
 


### PR DESCRIPTION
## Summary

- ignore non-voice `+CLCC` records in the cellular incoming-call monitor
- preserve the existing incoming direction and call-state checks
- add regression coverage for the packet-data record returned by EC20/EC25 firmware

## Problem

Some Quectel EC20/EC25 firmware reports an active packet-data session through `AT+CLCC`, for example:

```text
+CLCC: 1,1,0,1,0,"",128
```

Here `mode=1` identifies an asynchronous data call, but the monitor previously checked only direction and state. It therefore treated the record as an active incoming voice call and sent another notification after each 60-second deduplication window.

## Fix

Require `mode=0` (voice) before generating an incoming cellular call notification.

## Verification

- `npm ci --no-audit --no-fund && npm run build` in `web/`
- `go test ./...`
- cross-compiled a static Linux ARM64 binary
- deployed to an EC20/EC25 system exhibiting the issue; after more than one deduplication window, false call detections remained at zero while QMI data stayed connected and the web UI remained healthy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cellular call detection to recognize incoming voice calls across ringing, waiting, active, and alerting states.
  * Prevented packet-data sessions and outgoing calls from being incorrectly reported as incoming calls.

* **Tests**
  * Added coverage for voice-call detection and packet-data session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->