### PR TITLE
fix(ims): omit empty PANI call headers

### DIFF
--- a/internal/vowifi/ims/call_runtime.go
+++ b/internal/vowifi/ims/call_runtime.go
@@ -115,7 +115,9 @@ func (session *Session) DialCall(ctx context.Context, number string) (vowifi.Cal
 		"P-Preferred-Identity: <"+preferredIdentity+">",
 		"P-Preferred-Service: "+mmtelServiceURN,
 		`Accept-Contact: *;+g.3gpp.icsi-ref="`+mmtelFeatureTag+`"`,
-		"P-Access-Network-Info: "+session.pAccessNetworkInfo(),
+	)
+	lines = session.appendPAccessNetworkInfoHeader(lines)
+	lines = append(lines,
 		"User-Agent: "+session.imsUserAgent(),
 		"Allow: INVITE, ACK, CANCEL, BYE, OPTIONS, MESSAGE, PRACK, UPDATE, INFO",
 		"Supported: 100rel, timer, replaces",
@@ -499,7 +501,9 @@ func (session *Session) sendRejectedInviteACK(call *imsCall, response *sipRespon
 		"To: "+to,
 		"Call-ID: "+call.callID,
 		fmt.Sprintf("CSeq: %d ACK", call.cseq),
-		"P-Access-Network-Info: "+session.pAccessNetworkInfo(),
+	)
+	lines = session.appendPAccessNetworkInfoHeader(lines)
+	lines = append(lines,
 		"User-Agent: "+session.imsUserAgent(),
 		"Content-Length: 0", "", "",
 	)
@@ -577,7 +581,9 @@ func (session *Session) sendPRACK(call *imsCall, response *sipResponse) {
 	lines = append(lines,
 		"From: "+from, "To: "+to, "Call-ID: "+call.callID,
 		fmt.Sprintf("CSeq: %d PRACK", cseq), "RAck: "+rseq+" "+inviteCSeq,
-		"P-Access-Network-Info: "+session.pAccessNetworkInfo(),
+	)
+	lines = session.appendPAccessNetworkInfoHeader(lines)
+	lines = append(lines,
 		"User-Agent: "+session.imsUserAgent(),
 		"Content-Length: 0", "", "",
 	)
@@ -712,7 +718,7 @@ func (session *Session) buildDialogRequest(call *imsCall, method string, cseq ui
 		"User-Agent: "+session.imsUserAgent(),
 	)
 	if method != "CANCEL" {
-		lines = append(lines, "P-Access-Network-Info: "+session.pAccessNetworkInfo())
+		lines = session.appendPAccessNetworkInfoHeader(lines)
 	}
 	if method == "UPDATE" {
 		lines = append(lines, session.dialogContactHeader())
@@ -825,6 +831,13 @@ func (session *Session) pAccessNetworkInfo() string {
 		return session.pani
 	}
 	return resolveSessionPAccessNetworkInfo(session.request.Identity, session.imsLogger())
+}
+
+func (session *Session) appendPAccessNetworkInfoHeader(lines []string) []string {
+	if pani := session.pAccessNetworkInfo(); pani != "" {
+		return append(lines, "P-Access-Network-Info: "+pani)
+	}
+	return lines
 }
 
 func callResponseDiagnostic(response *sipResponse) string {

--- a/internal/vowifi/ims/call_runtime_test.go
+++ b/internal/vowifi/ims/call_runtime_test.go
@@ -263,14 +263,20 @@ func TestDialogRequestOmitsPAccessNetworkInfoWhenProfileDisablesPANI(t *testing.
 		t.Fatalf("disabled profile PANI = %q, want empty", pani)
 	}
 	client, peer := net.Pipe()
-	defer client.Close()
-	defer peer.Close()
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close client connection: %v", err)
+		}
+	})
+	t.Cleanup(func() {
+		if err := peer.Close(); err != nil {
+			t.Errorf("close peer connection: %v", err)
+		}
+	})
 	session := &Session{
-		request:      vowifi.IMSRequest{Identity: identity},
-		transport:    "tcp",
-		conn:         client,
-		pani:         pani,
-		paniResolved: true,
+		request:   vowifi.IMSRequest{Identity: identity},
+		transport: "tcp",
+		conn:      client,
 	}
 	call := &imsCall{
 		target: "sip:callee@example.test",

--- a/internal/vowifi/ims/call_runtime_test.go
+++ b/internal/vowifi/ims/call_runtime_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -236,6 +238,50 @@ func TestOutgoingLocalNumberUsesIMSPhoneContextAndMMTelHeaders(t *testing.T) {
 		if !strings.Contains(wire, expected) {
 			t.Fatalf("INVITE omitted %q:\n%s", expected, wire)
 		}
+	}
+}
+
+func TestDialogRequestOmitsPAccessNetworkInfoWhenProfileDisablesPANI(t *testing.T) {
+	profileDir := t.TempDir()
+	profile := `{"version":1,"profiles":[{"id":"test-pani-disabled","match":{"home_plmns":["00101"]},"ims":{"pani_enabled":false}}]}`
+	if err := os.WriteFile(filepath.Join(profileDir, "pani-disabled.json"), []byte(profile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	emptyProfileDir := t.TempDir()
+	t.Cleanup(func() {
+		if err := vowifi.LoadCarrierProfileDirectory(emptyProfileDir); err != nil {
+			t.Errorf("clear external carrier profiles: %v", err)
+		}
+	})
+	if err := vowifi.LoadCarrierProfileDirectory(profileDir); err != nil {
+		t.Fatal(err)
+	}
+
+	identity := vowifi.SIMIdentity{HomeMCC: "001", HomeMNC: "01", IMSI: "001010123456789"}
+	pani := resolveSessionPAccessNetworkInfo(identity, nil)
+	if pani != "" {
+		t.Fatalf("disabled profile PANI = %q, want empty", pani)
+	}
+	client, peer := net.Pipe()
+	defer client.Close()
+	defer peer.Close()
+	session := &Session{
+		request:      vowifi.IMSRequest{Identity: identity},
+		transport:    "tcp",
+		conn:         client,
+		pani:         pani,
+		paniResolved: true,
+	}
+	call := &imsCall{
+		target: "sip:callee@example.test",
+		from:   "<sip:caller@example.test>;tag=local",
+		to:     "<sip:callee@example.test>;tag=remote",
+		callID: "pani-disabled-call",
+	}
+
+	request := string(session.buildDialogRequest(call, "BYE", 2))
+	if strings.Contains(request, "\r\nP-Access-Network-Info:") {
+		t.Fatalf("BYE contains disabled P-Access-Network-Info header:\n%s", request)
 	}
 }
 


### PR DESCRIPTION
## Summary
- omit P-Access-Network-Info from call requests when the resolved PANI is empty
- cover a carrier profile with PANI disabled

## Tests
- go test ./internal/vowifi/ims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SIP call requests now omit the `P-Access-Network-Info` header when no network information is available or when the carrier profile disables it.
  - Applies consistently to call setup, acknowledgments, provisional responses, and dialog requests.

- **Tests**
  - Added coverage confirming dialog requests correctly exclude the header when PANI is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->