### PR TITLE
feat: show SMS channel registration status

### DIFF
--- a/web/src/components/devices/DeviceOverviewTab.tsx
+++ b/web/src/components/devices/DeviceOverviewTab.tsx
@@ -19,7 +19,7 @@ export interface DeviceOverviewTabProps {
   trafficMinuteTx: string;
   e911Starting: boolean;
   onSetupE911: () => void;
-  onRefresh: () => void;
+  onRefresh: () => void | Promise<void>;
 }
 
 export function DeviceOverviewTab(props: DeviceOverviewTabProps) {
@@ -45,6 +45,7 @@ export function DeviceOverviewTab(props: DeviceOverviewTabProps) {
           customPhoneNumber={props.customPhoneNumber}
           e911Starting={props.e911Starting}
           onSetupE911={props.onSetupE911}
+          onRefreshOverview={props.onRefresh}
         />
 		{showNetworkDetails ? <OverviewNetworkPanel
           device={device}

--- a/web/src/components/devices/OverviewSimPanel.tsx
+++ b/web/src/components/devices/OverviewSimPanel.tsx
@@ -6,6 +6,7 @@ import type { DeviceDetail } from "./types";
 import { useI18n } from "../../lib/i18n";
 import { carrierIso } from "../../lib/carrier";
 import { CountryFlag } from "../CountryFlag";
+import { SMSChannelStatusRow } from "./SMSChannelStatusRow";
 
 export interface OverviewSimPanelProps {
   device: DeviceDetail;
@@ -13,9 +14,10 @@ export interface OverviewSimPanelProps {
   customPhoneNumber?: string;
   e911Starting: boolean;
   onSetupE911: () => void;
+  onRefreshOverview: () => void | Promise<void>;
 }
 
-export function OverviewSimPanel({ device, simOperatorDisplay, customPhoneNumber, e911Starting, onSetupE911 }: OverviewSimPanelProps) {
+export function OverviewSimPanel({ device, simOperatorDisplay, customPhoneNumber, e911Starting, onSetupE911, onRefreshOverview }: OverviewSimPanelProps) {
   const { t } = useI18n();
   const [showSensitive, toggleSensitive] = useShowSensitive();
   const modem = device.modem;
@@ -43,6 +45,7 @@ export function OverviewSimPanel({ device, simOperatorDisplay, customPhoneNumber
         <FieldRow label="ICCID" value={modem?.iccid} sensitive={sensitive} monospace copyable />
         <FieldRow label="IMSI" value={modem?.imsi} sensitive={sensitive} monospace copyable />
         <FieldRow label={t("本机号码")} value={displayedPhoneNumber} sensitive={sensitive} monospace copyable />
+        <SMSChannelStatusRow device={device} onRefreshOverview={onRefreshOverview} />
         {device?.e911SetupAvailable ? (
           <div className="flex justify-between gap-3">
             <span className="text-gray-500">{t("E911地址")}</span>

--- a/web/src/components/devices/SMSChannelStatusRow.tsx
+++ b/web/src/components/devices/SMSChannelStatusRow.tsx
@@ -58,13 +58,16 @@ export function SMSChannelStatusRow({ device, onRefreshOverview }: SMSChannelSta
   const refresh = async () => {
     if (loading) return;
     if (usesVoWiFi) {
+      const sequence = ++requestSequence.current;
       setLoading(true);
       try {
         await onRefreshOverview();
       } catch (error) {
-        message.error(apiMessage(error) || t("刷新短信通道状态失败"));
+        if (sequence === requestSequence.current) {
+          message.error(apiMessage(error) || t("刷新短信通道状态失败"));
+        }
       } finally {
-        setLoading(false);
+        if (sequence === requestSequence.current) setLoading(false);
       }
       return;
     }

--- a/web/src/components/devices/SMSChannelStatusRow.tsx
+++ b/web/src/components/devices/SMSChannelStatusRow.tsx
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowSyncRegular } from "@fluentui/react-icons";
+import { Tag, type TagType } from "../ui/Tag";
+import { cx } from "../../lib/utils";
+import { useI18n } from "../../lib/i18n";
+import { getCellularIMS, type CellularIMSStatus } from "./deviceActions";
+import { isDeviceOnline } from "./shared";
+import type { DeviceDetail } from "./types";
+
+interface SMSChannelStatusRowProps {
+  device: DeviceDetail;
+  onRefreshOverview: () => void | Promise<void>;
+}
+
+interface DisplayStatus {
+  label: string;
+  tone: TagType;
+}
+
+export function SMSChannelStatusRow({ device, onRefreshOverview }: SMSChannelStatusRowProps) {
+  const { t } = useI18n();
+  const [cellular, setCellular] = useState<CellularIMSStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const requestSequence = useRef(0);
+
+  const iccid = (device.modem?.iccid || "").trim();
+  const usesVoWiFi = device.deviceType === "usb_sim_reader" || !!device.vowifiEnabled;
+  const canProbeCellular = !usesVoWiFi && isDeviceOnline(device) && !!iccid && device.modem?.simInserted !== false;
+
+  const probeCellular = useCallback(async () => {
+    if (!canProbeCellular) return;
+    const sequence = ++requestSequence.current;
+    setLoading(true);
+    try {
+      const next = await getCellularIMS(device.id);
+      if (sequence === requestSequence.current) setCellular(next);
+    } catch {
+      if (sequence === requestSequence.current) setCellular(null);
+    } finally {
+      if (sequence === requestSequence.current) setLoading(false);
+    }
+  }, [canProbeCellular, device.id]);
+
+  // The overview tab is conditionally mounted, so this runs once when users
+  // return to it and again when the active device/SIM/profile changes.
+  useEffect(() => {
+    requestSequence.current += 1;
+    setCellular(null);
+    setLoading(false);
+    if (canProbeCellular) void probeCellular();
+    return () => {
+      requestSequence.current += 1;
+    };
+  }, [canProbeCellular, device.id, iccid, device.activeEsimProfileName, probeCellular]);
+
+  const refresh = async () => {
+    if (loading) return;
+    if (usesVoWiFi) {
+      setLoading(true);
+      try {
+        await onRefreshOverview();
+      } finally {
+        setLoading(false);
+      }
+      return;
+    }
+    await probeCellular();
+  };
+
+  let display: DisplayStatus;
+  if (usesVoWiFi) {
+    if (device.vowifiRuntime?.smsReady) display = { label: t("已就绪(VoWiFi)"), tone: "success" };
+    else if (device.vowifiRuntime?.imsReady) display = { label: t("已注册(IMS)"), tone: "success" };
+    else if (device.vowifiRuntime?.enabled) display = { label: t("未注册短信域"), tone: "warning" };
+    else display = { label: t("状态未知"), tone: "info" };
+  } else if (!canProbeCellular || !cellular) {
+    display = { label: t("状态未知"), tone: "info" };
+  } else if (cellular.registered && cellular.csRegistered) {
+    display = { label: t("已注册(CS, IMS)"), tone: "success" };
+  } else if (cellular.registered) {
+    display = { label: t("已注册(IMS)"), tone: "success" };
+  } else if (cellular.csRegistered) {
+    display = { label: t("已注册(CS)"), tone: "success" };
+  } else if (cellular.csKnown && cellular.supported) {
+    display = { label: t("未注册短信域"), tone: "warning" };
+  } else {
+    display = { label: t("状态未知"), tone: "info" };
+  }
+
+  return (
+    <div className="flex w-full min-w-0 items-center justify-between gap-3">
+      <span className="shrink-0 whitespace-nowrap text-gray-500">{t("短信通道")}</span>
+      <div className="flex min-w-0 items-center justify-end gap-1.5">
+        <Tag type={display.tone}>{display.label}</Tag>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          disabled={loading}
+          title={t("刷新短信通道状态")}
+          aria-label={t("刷新短信通道状态")}
+          className="rounded p-1 text-gray-400 transition-colors hover:bg-black/5 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-white/10 dark:hover:text-gray-200"
+        >
+          <ArrowSyncRegular className={cx("h-4 w-4", loading && "animate-spin")} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/devices/SMSChannelStatusRow.tsx
+++ b/web/src/components/devices/SMSChannelStatusRow.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowSyncRegular } from "@fluentui/react-icons";
+import { apiMessage } from "../../api";
 import { Tag, type TagType } from "../ui/Tag";
+import { message } from "../ui";
 import { cx } from "../../lib/utils";
 import { useI18n } from "../../lib/i18n";
 import { getCellularIMS, type CellularIMSStatus } from "./deviceActions";
@@ -59,6 +61,8 @@ export function SMSChannelStatusRow({ device, onRefreshOverview }: SMSChannelSta
       setLoading(true);
       try {
         await onRefreshOverview();
+      } catch (error) {
+        message.error(apiMessage(error) || t("刷新短信通道状态失败"));
       } finally {
         setLoading(false);
       }

--- a/web/src/components/devices/SMSChannelStatusRow.tsx
+++ b/web/src/components/devices/SMSChannelStatusRow.tsx
@@ -6,7 +6,7 @@ import { message } from "../ui";
 import { cx } from "../../lib/utils";
 import { useI18n } from "../../lib/i18n";
 import { getCellularIMS, type CellularIMSStatus } from "./deviceActions";
-import { isDeviceOnline } from "./shared";
+import { isDeviceOnline, isVoWiFiInUse } from "./shared";
 import type { DeviceDetail } from "./types";
 
 interface SMSChannelStatusRowProps {
@@ -26,7 +26,7 @@ export function SMSChannelStatusRow({ device, onRefreshOverview }: SMSChannelSta
   const requestSequence = useRef(0);
 
   const iccid = (device.modem?.iccid || "").trim();
-  const usesVoWiFi = device.deviceType === "usb_sim_reader" || !!device.vowifiEnabled;
+  const usesVoWiFi = isVoWiFiInUse(device) && !(device.modem?.imei && device.modem?.simInserted === false);
   const canProbeCellular = !usesVoWiFi && isDeviceOnline(device) && !!iccid && device.modem?.simInserted !== false;
 
   const probeCellular = useCallback(async () => {

--- a/web/src/components/devices/SMSChannelStatusRow.tsx
+++ b/web/src/components/devices/SMSChannelStatusRow.tsx
@@ -53,7 +53,7 @@ export function SMSChannelStatusRow({ device, onRefreshOverview }: SMSChannelSta
     return () => {
       requestSequence.current += 1;
     };
-  }, [canProbeCellular, device.id, iccid, device.activeEsimProfileName, probeCellular]);
+  }, [canProbeCellular, device.id, iccid, device.activeEsimProfileName, usesVoWiFi, probeCellular]);
 
   const refresh = async () => {
     if (loading) return;

--- a/web/src/lib/i18n-en.ts
+++ b/web/src/lib/i18n-en.ts
@@ -1208,6 +1208,14 @@ export const EN_DICT: Record<string, string> = {
   // Additional missing system strings
   "端口": "Port",
   "错误详情": "Error Details",
+  "短信通道": "SMS channel",
+  "刷新短信通道状态": "Refresh SMS channel status",
+  "已注册(CS)": "Registered (CS)",
+  "已注册(IMS)": "Registered (IMS)",
+  "已注册(CS, IMS)": "Registered (CS, IMS)",
+  "已就绪(VoWiFi)": "Ready (VoWiFi)",
+  "未注册短信域": "No SMS domain registered",
+  "状态未知": "Unknown",
   "正在搜索网络": "Searching network",
   "SM-DP+ 的公开 Profile 库存已耗尽，请稍后重试或更换服务。":
     "The public profile inventory on the SM-DP+ is exhausted. Please try again later or use a different service.",
@@ -1218,4 +1226,3 @@ export const EN_DICT: Record<string, string> = {
   "已发现该模组，但未找到 AT 串口：通常是 option 驱动未认该 PID 或模组处于 MBIM/RNDIS 组态。可 ":
     "Modem detected, but no AT serial port found: option driver may not recognize this PID or modem is in MBIM/RNDIS mode. You can ",
 };
-

--- a/web/src/lib/i18n-en.ts
+++ b/web/src/lib/i18n-en.ts
@@ -1210,6 +1210,7 @@ export const EN_DICT: Record<string, string> = {
   "错误详情": "Error Details",
   "短信通道": "SMS channel",
   "刷新短信通道状态": "Refresh SMS channel status",
+  "刷新短信通道状态失败": "Failed to refresh SMS channel status",
   "已注册(CS)": "Registered (CS)",
   "已注册(IMS)": "Registered (IMS)",
   "已注册(CS, IMS)": "Registered (CS, IMS)",


### PR DESCRIPTION
## Background

After configuring cellular IMS SMS, users still cannot tell from the overview whether the modem is registered on the CS domain, IMS domain, both, or whether VoWiFi SMS is ready. This adds a lightweight status indicator without introducing continuous polling or message-delivery verification.

## Changes

- Add an SMS channel row to the SIM / device card on the overview page.
- Display one of: Registered (CS), Registered (IMS), Registered (CS, IMS), Ready (VoWiFi), No SMS domain registered, or Unknown.
- Probe once when entering or returning to Overview, or when the selected device, ICCID, or eSIM profile changes.
- Add a manual refresh button.
- Protect against stale async responses when device/card context changes.
- Add English translations for the new UI strings.

## Request and refresh behavior

- Cellular devices reuse the existing cellular IMS status endpoint; no new backend API is introduced.
- VoWiFi devices use the existing runtime state and refresh it through the overview refresh action.
- No interval timer or background polling is added.

## Semantics and impact

“Registered” reports the registration state exposed by the modem/runtime. It does not claim that an SMS has been sent or received successfully. The change is limited to the web UI and reuses existing status data and APIs.

## Testing

- `npm test`: 8/8 passed.
- `npm run build`: passed.
- Manually verified on an N1 with a CTExcel profile: IMS-only state renders as Registered (IMS), manual refresh works, and leaving/returning to Overview triggers a fresh request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SMS channel status information to the device overview.
  * Displayed cellular registration, IMS, VoWiFi readiness, and SMS domain status.
  * Added a refresh control with loading feedback for status updates.
  * Added localized English labels and status messages.

* **Bug Fixes**
  * Improved handling of immediate and asynchronous refreshes.
  * Prevented outdated status responses from replacing newer results.
  * Added feedback when status refreshes fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->