### PR TITLE
fix(device): restore SIM power when QMI recovery is canceled

### DIFF
--- a/internal/device/vowifi_qmi.go
+++ b/internal/device/vowifi_qmi.go
@@ -130,10 +130,22 @@ func openNativeQMIChannelWithRecovery(
 	if powerErr := session.PowerOffSIM(ctx, slot); powerErr != nil {
 		return 0, errors.Join(err, fmt.Errorf("power off QMI UIM slot %d: %w", slot, powerErr))
 	}
+	restorePower := func() error {
+		cleanupContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		return session.PowerOnSIM(cleanupContext, slot)
+	}
 	if waitErr := waitNativeQMIRecovery(ctx, 3*time.Second); waitErr != nil {
+		// Power-off succeeded, so cancellation of the caller must not strand the
+		// physical SIM in power-down. Restore power with a bounded cleanup context
+		// that survives an HTTP/UI request being canceled.
+		powerErr := restorePower()
+		if powerErr != nil {
+			return 0, errors.Join(err, waitErr, fmt.Errorf("restore power to QMI UIM slot %d: %w", slot, powerErr))
+		}
 		return 0, errors.Join(err, waitErr)
 	}
-	if powerErr := session.PowerOnSIM(ctx, slot); powerErr != nil {
+	if powerErr := restorePower(); powerErr != nil {
 		return 0, errors.Join(err, fmt.Errorf("power on QMI UIM slot %d: %w", slot, powerErr))
 	}
 	if waitErr := waitNativeQMIRecovery(ctx, 5*time.Second); waitErr != nil {


### PR DESCRIPTION
## Summary

- restore SIM power if QMI UIM recovery is canceled after a successful power-off
- use a bounded cleanup context that is independent of the canceled HTTP/UI request
- keep the existing recovery behavior unchanged outside this cancellation path

## Problem

On OpenStick 410, editing an eSIM profile policy can cancel the request while QMI UIM resource recovery is waiting. The SIM has already been powered off at that point, so returning immediately leaves the slot in `power-down` and ICCID/IMSI disappear until power is restored.

## Validation

- `go test ./internal/device ./internal/server ./internal/vowifi/... ./cmd/vocat`
- reproduced and validated on OpenStick 410
- PR contains only `internal/device/vowifi_qmi.go`; test and build artifact files are excluded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VoWiFi connectivity recovery when the device temporarily loses access to the SIM.
  - SIM power is now restored reliably during recovery, including when recovery encounters a timeout or other failure.
  - Enhanced error reporting helps surface issues that occur while restoring SIM functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->