### PR TITLE
fix(vowifi): enable IMS SMS submission on OpenStick 410

### DIFF
--- a/cmd/vocat/native_qmi_vowifi.go
+++ b/cmd/vocat/native_qmi_vowifi.go
@@ -35,6 +35,10 @@ func (mapper nativeQMIControllerMapper) ReadSIMMetadata(ctx context.Context, id 
 	return mapper.Mapper.ReadSIMMetadata(ctx, id)
 }
 
+func (mapper nativeQMIControllerMapper) ReadSMSCenter(ctx context.Context, id string) (string, error) {
+	return mapper.Mapper.ReadSMSCenter(ctx, id)
+}
+
 func (mapper nativeQMIControllerMapper) ProbeNativeQMIApplication(ctx context.Context, id, preference string) ([]byte, string, error) {
 	physical, err := mapper.physical(id)
 	if err != nil {

--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -242,10 +242,6 @@ func (s *Server) handleSMSSend(w http.ResponseWriter, r *http.Request) {
 		s.writeStoreError(w, err)
 		return
 	}
-	if store.NormalizeDeviceType(config.DeviceType) == store.DeviceTypeWiFi410 {
-		writeError(w, http.StatusNotImplemented, "device_feature_unsupported", "SMS is not supported by the native OpenStick 410 backend")
-		return
-	}
 	entry, physicalID, present := s.physicalForConfig(config)
 	if !s.requirePhysicalDevice(w, present) {
 		return
@@ -290,6 +286,13 @@ func (s *Server) handleSMSSend(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+	}
+	// Native OpenStick 410 supports SMS only through an established VoWiFi IMS
+	// session. Keep cellular AT+CMGS disabled until that modem path is separately
+	// implemented and validated; never silently fall back from IMS to cellular.
+	if store.NormalizeDeviceType(config.DeviceType) == store.DeviceTypeWiFi410 {
+		writeError(w, http.StatusConflict, "ims_sms_not_ready", "OpenStick 410 requires a ready VoWiFi IMS SMS session")
+		return
 	}
 	result, sendErr := s.devices.SendSMS(
 		r.Context(),

--- a/internal/vowifi/integration/at.go
+++ b/internal/vowifi/integration/at.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"vocat/internal/device"
@@ -72,6 +73,43 @@ func (mapper ATMapper) ExecuteSensitiveAT(
 		return modem.Response{}, err
 	}
 	return mapper.Devices.ExecuteSensitiveAT(ctx, physicalID, command)
+}
+
+// ReadSMSCenter reads the SIM-provisioned service-centre address through the
+// modem's read-only AT interface. Native QMI devices still expose a companion
+// AT port, and SMS-over-IMS needs this value to address RP-DATA submissions.
+func (mapper ATMapper) ReadSMSCenter(ctx context.Context, configuredID string) (string, error) {
+	response, err := mapper.ExecuteAT(ctx, configuredID, "AT+CSCA?")
+	if err != nil {
+		return "", fmt.Errorf("read SMS service centre: %w", err)
+	}
+	for _, line := range response.Lines {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "+CSCA:") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, "+CSCA:"))
+		if comma := strings.IndexByte(value, ','); comma >= 0 {
+			value = value[:comma]
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"`)
+		digits := strings.TrimPrefix(value, "+")
+		if len(digits) < 3 || len(digits) > 20 {
+			break
+		}
+		valid := true
+		for _, digit := range digits {
+			if digit < '0' || digit > '9' {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			return value, nil
+		}
+		break
+	}
+	return "", errors.New("modem returned no valid SMS service-centre address")
 }
 
 // ReadSIMMetadata reuses the device manager's per-ICCID EF cache. VoWiFi

--- a/internal/vowifi/native_qmi_adapter.go
+++ b/internal/vowifi/native_qmi_adapter.go
@@ -37,6 +37,7 @@ type nativeQMIBinding struct {
 
 var _ SIMIdentityReader = (*NativeQMIAdapter)(nil)
 var _ PreferredAKAProvider = (*NativeQMIAdapter)(nil)
+var _ SMSCenterReader = (*NativeQMIAdapter)(nil)
 var _ RadioController = (*NativeQMIAdapter)(nil)
 
 func NewNativeQMIAdapter(controller NativeQMIController, purePolicy func(string) bool) (*NativeQMIAdapter, error) {
@@ -71,6 +72,14 @@ func (adapter *NativeQMIAdapter) ReadIdentity(ctx context.Context, deviceID stri
 	adapter.bindings[identity.ICCID] = nativeQMIBinding{deviceID: deviceID, iccid: identity.ICCID, imsi: identity.IMSI}
 	adapter.mu.Unlock()
 	return identity, nil
+}
+
+func (adapter *NativeQMIAdapter) ReadSMSCenter(ctx context.Context, deviceID string) (string, error) {
+	reader, ok := adapter.controller.(SMSCenterReader)
+	if !ok {
+		return "", errors.New("vocat: native QMI controller does not expose an SMS service-centre reader")
+	}
+	return reader.ReadSMSCenter(ctx, deviceID)
 }
 
 func (adapter *NativeQMIAdapter) binding(identity SIMIdentity) (nativeQMIBinding, error) {

--- a/web/src/pages/SmsPage.tsx
+++ b/web/src/pages/SmsPage.tsx
@@ -60,12 +60,10 @@ function showSmsSendOutcome(result: SmsSendResult) {
       message.success("短信已确认送达");
       return;
     case "accepted_unconfirmed":
-      message.info(
-        result.transport === "ims"
-          ? "IMS 已接受短信提交，但尚未收到收件人送达确认"
-          : "模块已接受短信提交，但尚未收到运营商送达确认",
-        5000,
-      );
+      // Keep the user-facing result identical across cellular AT (EC20) and
+      // VoWiFi IMS (410). The transport remains available in the API response
+      // for diagnostics, but it must not change the meaning shown to users.
+      message.info("模块已接受短信提交，但尚未收到运营商送达确认", 5000);
       return;
     case "partial":
       message.warning(`短信仅有 ${accepted}/${total} 段被接受，不能判定为发送成功`, 5000);


### PR DESCRIPTION
## Summary

- allow OpenStick 410 to submit SMS through an established VoWiFi IMS session while keeping cellular `AT+CMGS` fallback disabled
- expose the SIM-provisioned SMSC to the native QMI adapter through the companion AT port so IMS RP-DATA can be constructed correctly
- use the same accepted-but-unconfirmed UI feedback for EC20 cellular submissions and 410 IMS submissions

## Scope

- destination restrictions are unchanged, including the existing `+86` restriction
- no test files or generated build artifacts are included
- change is limited to five production source files

## Verification

- `npm test`
- `npm run build`
- `go test ./internal/server ./internal/vowifi/... ./cmd/vocat ./web`
- verified on an AArch64 OpenStick 410: VoWiFi reached `sms_ready`, IMS accepted the SMS submission, and the cellular SMS path was not used

The complete Go suite was also exercised; all affected packages passed. The unrelated Windows-only `internal/qmiport` device-node replacement test remains subject to an existing file-lock race on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading the SMS service-center number across compatible cellular and VoWiFi devices.
  * Improved handling of SMS delivery on OpenStick 410 devices when VoWiFi IMS is unavailable.

* **Bug Fixes**
  * Standardized informational messaging for unconfirmed SMS results across cellular and VoWiFi transports.
  * Prevented unsupported fallback behavior when IMS SMS delivery cannot proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->