### PR TITLE
fix(sms): enable reliable cellular SMS receive on OpenStick 410

### DIFF
--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -622,6 +622,17 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 		if !present {
 			continue
 		}
+		// OpenStick 410 controls cellular registration through QMI but receives
+		// stored SMS through its AT port. Its firmware can reset CNMI after a
+		// profile switch, leaving newly delivered SMS invisible to VoCat.
+		if store.NormalizeDeviceType(config.DeviceType) == store.DeviceTypeWiFi410 {
+			setupContext, cancelSetup := context.WithTimeout(ctx, 5*time.Second)
+			_, setupErr := s.devices.ExecuteAT(setupContext, physicalID, `AT+CNMI=2,1,0,0,0`)
+			cancelSetup()
+			if setupErr != nil {
+				s.logger.Debug("OpenStick 410 cellular SMS notification setup skipped", "device_id", config.ID, "error", setupErr)
+			}
+		}
 		listContext, cancelList := context.WithTimeout(ctx, 30*time.Second)
 		messages, err := s.devices.ListSMS(listContext, physicalID)
 		cancelList()
@@ -696,6 +707,9 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 				"message_reference":  message.MessageReference,
 				"delivery_status":    message.DeliveryStatus,
 				"data_coding_scheme": message.DataCodingScheme,
+				// Mark 410 rows so completed multipart messages retain their durable
+				// id when its modem storage is decoded again on the next poll.
+				"keep_durable_id_on_rescan": store.NormalizeDeviceType(config.DeviceType) == store.DeviceTypeWiFi410,
 			})
 			saved, saveErr := s.store.SaveSMSMessage(ctx, store.SMSMessage{
 				MessageID:     messageID,
@@ -729,7 +743,13 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 
 func supportsModemSMSStorage(config store.Device) bool {
 	deviceType := store.NormalizeDeviceType(config.DeviceType)
-	return deviceType != store.DeviceTypeUSBSIMReader && deviceType != store.DeviceTypeWiFi410
+	if deviceType == store.DeviceTypeUSBSIMReader {
+		return false
+	}
+	if deviceType == store.DeviceTypeWiFi410 {
+		return strings.TrimSpace(config.ATPort) != ""
+	}
+	return true
 }
 
 func shouldDeferModemSMSSync(state vowifi.State, stateErr error) bool {

--- a/internal/store/sms.go
+++ b/internal/store/sms.go
@@ -102,19 +102,38 @@ func saveSMSMessage(
 				}
 				return existing, nil
 			}
-			// A new segment advanced the message. Replace the stale partial row so
-			// the merged row receives a fresh durable id; the Telegram id-cursor
-			// then surfaces the now-more-complete message exactly once. Carry
-			// forward identity and history fields.
-			if _, delErr := executor.ExecContext(ctx, `DELETE FROM sms_messages WHERE id = ?`, existing.ID); delErr != nil {
-				return SMSMessage{}, fmt.Errorf("replace concatenated SMS: %w", delErr)
-			}
-			value.ID = 0
-			value.CreatedAt = existing.CreatedAt
-			value.Read = value.Read || existing.Read
-			if !existing.Timestamp.IsZero() &&
-				(value.Timestamp.IsZero() || existing.Timestamp.Before(value.Timestamp)) {
-				value.Timestamp = existing.Timestamp
+			// Once a concatenated message is complete, keep its durable row id
+			// stable even if a later modem rescan presents one segment in a
+			// slightly different decoded form. Notification consumers use this id
+			// as their cursor; deleting and reinserting a completed row would make
+			// an old stored SMS look new and repeatedly notify it on every scan.
+			// Partial rows still receive a fresh id when they become complete so a
+			// consumer that already skipped the partial row can surface it once.
+			if ConcatSMSReadyToNotify(existing.MessageID, existing.Extra) && concatSMSKeepsDurableID(extra) {
+				value.ID = existing.ID
+				value.CreatedAt = existing.CreatedAt
+				value.Read = value.Read || existing.Read
+				if !existing.Timestamp.IsZero() &&
+					(value.Timestamp.IsZero() || existing.Timestamp.Before(value.Timestamp)) {
+					value.Timestamp = existing.Timestamp
+				}
+				value.Body = mergedBody
+				extra = mergedExtra
+			} else {
+				// A new segment advanced the message. Replace the stale partial row so
+				// the merged row receives a fresh durable id; the Telegram id-cursor
+				// then surfaces the now-more-complete message exactly once. Carry
+				// forward identity and history fields.
+				if _, delErr := executor.ExecContext(ctx, `DELETE FROM sms_messages WHERE id = ?`, existing.ID); delErr != nil {
+					return SMSMessage{}, fmt.Errorf("replace concatenated SMS: %w", delErr)
+				}
+				value.ID = 0
+				value.CreatedAt = existing.CreatedAt
+				value.Read = value.Read || existing.Read
+				if !existing.Timestamp.IsZero() &&
+					(value.Timestamp.IsZero() || existing.Timestamp.Before(value.Timestamp)) {
+					value.Timestamp = existing.Timestamp
+				}
 			}
 		}
 		value.Body = mergedBody

--- a/internal/store/sms_reassembly.go
+++ b/internal/store/sms_reassembly.go
@@ -38,6 +38,15 @@ func ConcatSMSReadyToNotify(messageID string, extra json.RawMessage) bool {
 	return complete
 }
 
+func concatSMSKeepsDurableID(extra json.RawMessage) bool {
+	document, err := decodeJSONObject(extra)
+	if err != nil {
+		return false
+	}
+	keep, _ := document["keep_durable_id_on_rescan"].(bool)
+	return keep
+}
+
 // StableConcatMessageID builds the message id shared by every segment of one
 // concatenated SMS. The UDH concat reference is only unique per sender, so the
 // hardware identity and peer scope it; total is folded in to further separate the
@@ -126,7 +135,7 @@ func mergeConcatSegment(
 		"concat_complete": complete,
 	}
 	// Preserve non-concat metadata from the latest segment for context.
-	for _, key := range []string{"encoding", "storage", "transport", "source"} {
+	for _, key := range []string{"encoding", "storage", "transport", "source", "keep_durable_id_on_rescan"} {
 		if value, ok := segment[key]; ok {
 			merged[key] = value
 		}


### PR DESCRIPTION
## Summary

Fix cellular SMS reception and repeated notification delivery on OpenStick 410 devices.

## Root cause

- OpenStick 410 was excluded from modem SMS storage polling, although the device receives cellular SMS through its AT port.
- The modem can reset `CNMI` after profile or radio state changes, so new stored messages may not be announced.
- Re-scanning an already completed multipart SMS could replace its database row when decoding differed slightly, giving it a new durable ID. Notification cursors then treated the historical SMS as new and repeatedly sent Bark notifications.

## Changes

- Enable modem SMS storage polling for `wifi_410` only when an AT port is configured.
- Reapply `AT+CNMI=2,1,0,0,0` before the OpenStick 410 storage scan.
- Tag only `wifi_410` storage rows for rescan idempotency.
- Preserve the durable ID of an already completed multipart 410 SMS during later full-storage scans.
- Keep the existing partial-to-complete ID transition, so a newly completed multipart SMS is still notified once.

## Scope

The new polling and durable-ID guard are limited to `device_type=wifi_410`. EC20/EC25, USB SIM readers, and VoWiFi IMS receive paths retain their existing behavior.

This PR contains only the three modified production source files; local regression test files and deployment artifacts are not included.

## Verification

- `go test ./internal/store ./internal/server ./internal/device -count=1`
- Deployed to an ARM64 OpenStick 410 running v0.2.21-based code.
- Verified cellular SMS import remains available.
- Observed multiple 15-second storage polling cycles with stable SMS row IDs.
- Confirmed historical multipart messages no longer generate repeated Bark notifications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SMS synchronization now supports compatible WiFi410 devices with an available AT port.
  * The system configures SMS notifications before retrieving stored messages.
* **Bug Fixes**
  * SMS synchronization continues when notification setup cannot be completed.
  * Concatenated messages now retain their notification history and durable identity when safely updated, preventing unnecessary replacement.
  * Message metadata is preserved more consistently during SMS rescans and reassembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->