### PR TITLE
refactor(telegram): streamline interactive bot menus

### DIFF
--- a/internal/server/settings_api.go
+++ b/internal/server/settings_api.go
@@ -927,19 +927,40 @@ func restrictedHTTPClient(
 	timeout time.Duration,
 	proxy string,
 ) (*http.Client, error) {
+	return newRestrictedHTTPClient(ctx, timeout, proxy, false)
+}
+
+func persistentRestrictedHTTPClient(
+	ctx context.Context,
+	timeout time.Duration,
+	proxy string,
+) (*http.Client, error) {
+	return newRestrictedHTTPClient(ctx, timeout, proxy, true)
+}
+
+func newRestrictedHTTPClient(
+	ctx context.Context,
+	timeout time.Duration,
+	proxy string,
+	keepAlives bool,
+) (*http.Client, error) {
 	timeout = clampNotificationTimeout(timeout)
 	transport := &http.Transport{
 		Proxy:                 nil,
 		DialContext:           restrictedDialer(timeout),
 		ForceAttemptHTTP2:     true,
-		DisableKeepAlives:     true,
-		MaxIdleConns:          0,
+		DisableKeepAlives:     !keepAlives,
+		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   timeout,
 		ResponseHeaderTimeout: timeout,
 		ExpectContinueTimeout: time.Second,
 		TLSClientConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},
+	}
+	if keepAlives {
+		transport.MaxIdleConns = 8
+		transport.MaxIdleConnsPerHost = 4
 	}
 	if strings.TrimSpace(proxy) != "" {
 		parsed, err := validateNotificationProxyURL(ctx, proxy)

--- a/internal/server/telegram_bot.go
+++ b/internal/server/telegram_bot.go
@@ -46,6 +46,10 @@ type telegramRuntimeConfig struct {
 type telegramBot struct {
 	server *Server
 
+	clientMu    sync.Mutex
+	clientProxy string
+	client      *http.Client
+
 	pendingMu sync.Mutex
 	pending   map[string]telegramPendingAction
 
@@ -115,6 +119,8 @@ type telegramCallbackQuery struct {
 	Message *telegramMessage `json:"message"`
 	Data    string           `json:"data"`
 }
+
+type telegramMenuMessageContextKey struct{}
 
 // StartTelegramBot starts both the Telegram command poller and durable inbound
 // SMS notifier. Configuration is reloaded between polls, so saving Settings
@@ -409,6 +415,7 @@ func (bot *telegramBot) handleUpdate(ctx context.Context, config telegramRuntime
 func (bot *telegramBot) handleCallback(ctx context.Context, config telegramRuntimeConfig, callback *telegramCallbackQuery) {
 	data := strings.TrimSpace(callback.Data)
 	chatID, adminID := callback.Message.Chat.ID, callback.From.ID
+	ctx = context.WithValue(ctx, telegramMenuMessageContextKey{}, callback.Message.MessageID)
 	if data == "menu:home" || data == "menu:devices" {
 		if data == "menu:home" {
 			bot.sendMainMenu(ctx, config, chatID)
@@ -556,7 +563,7 @@ func (bot *telegramBot) homeKeyboard() map[string]any {
 
 func (bot *telegramBot) sendMainMenu(ctx context.Context, config telegramRuntimeConfig, chatID int64) {
 	bot.clearInput(chatID, config.AdminID)
-	bot.sendText(ctx, config, chatID,
+	bot.sendMenuText(ctx, config, chatID,
 		"Vocat 控制中心\n\n请选择设备或直接查看全部设备状态。发送 /menu 可随时返回这里。",
 		telegramKeyboard(
 			[]map[string]string{telegramButton("📱 设备操作", "menu:devices")},
@@ -601,14 +608,14 @@ func (bot *telegramBot) sendDevicePicker(
 	}
 	rows = append(rows, []map[string]string{telegramButton("🏠 主菜单", "menu:home")})
 	if len(configs) == 0 {
-		bot.sendText(ctx, config, chatID, "当前没有已配置设备。", telegramKeyboard(rows...))
+		bot.sendMenuText(ctx, config, chatID, "当前没有已配置设备。", telegramKeyboard(rows...))
 		return
 	}
 	title := "请选择要操作的设备"
 	if next != "" {
 		title += "："
 	}
-	bot.sendText(ctx, config, chatID, title, telegramKeyboard(rows...))
+	bot.sendMenuText(ctx, config, chatID, title, telegramKeyboard(rows...))
 }
 
 func truncateTelegramButton(value string) string {
@@ -643,7 +650,7 @@ func (bot *telegramBot) sendDeviceMenu(
 	if present {
 		status = "🟢 在线"
 	}
-	bot.sendText(ctx, config, chatID,
+	bot.sendMenuText(ctx, config, chatID,
 		fmt.Sprintf("📡 %s\n设备 ID：%s\n状态：%s\n\n请选择功能：", firstNonEmpty(stored.Name, deviceID), deviceID, status),
 		telegramKeyboard(
 			[]map[string]string{
@@ -718,7 +725,7 @@ func (bot *telegramBot) sendVoWiFiMenu(ctx context.Context, config telegramRunti
 	if err != nil {
 		return
 	}
-	bot.sendText(ctx, config, chatID,
+	bot.sendMenuText(ctx, config, chatID,
 		fmt.Sprintf("📶 %s · VoWiFi\n策略：%s\n阶段：%s\nTunnel：%t · IMS：%t · SMS：%t", deviceID, map[bool]string{true: "已启用", false: "已关闭"}[stored.VoWiFiEnabled], firstNonEmpty(string(state.Phase), "idle"), state.TunnelReady, state.IMSReady, state.SMSReady),
 		telegramKeyboard(
 			[]map[string]string{
@@ -743,7 +750,7 @@ func (bot *telegramBot) sendCallMenu(ctx context.Context, config telegramRuntime
 	if err != nil {
 		return
 	}
-	bot.sendText(ctx, config, chatID, "📞 "+deviceID+" · 通话\n请选择操作：",
+	bot.sendMenuText(ctx, config, chatID, "📞 "+deviceID+" · 通话\n请选择操作：",
 		telegramKeyboard(
 			[]map[string]string{telegramButton("📱 拨打电话", "call:"+token+":dial")},
 			[]map[string]string{
@@ -772,7 +779,7 @@ func (bot *telegramBot) sendToolsMenu(ctx context.Context, config telegramRuntim
 	if err != nil {
 		return
 	}
-	bot.sendText(ctx, config, chatID, "🛠 "+deviceID+" · 调试与运营商指令\n请选择输入类型：",
+	bot.sendMenuText(ctx, config, chatID, "🛠 "+deviceID+" · 高级工具\n请选择操作：",
 		telegramKeyboard(
 			[]map[string]string{
 				telegramButton("⌨️ AT 指令", "d:"+token+":at"),
@@ -784,7 +791,7 @@ func (bot *telegramBot) sendToolsMenu(ctx context.Context, config telegramRuntim
 }
 
 func (bot *telegramBot) sendExpiredMenu(ctx context.Context, config telegramRuntimeConfig, chatID int64) {
-	bot.sendText(ctx, config, chatID, "该菜单已过期，请重新选择。", bot.homeKeyboard())
+	bot.sendMenuText(ctx, config, chatID, "该菜单已过期，请重新选择。", bot.homeKeyboard())
 }
 
 func (bot *telegramBot) sendHelp(ctx context.Context, config telegramRuntimeConfig, chatID int64) {
@@ -811,7 +818,7 @@ func (bot *telegramBot) sendHelp(ctx context.Context, config telegramRuntimeConf
 		[]map[string]string{telegramButton("📱 使用操作菜单", "menu:devices")},
 		[]map[string]string{telegramButton("🏠 主菜单", "menu:home")},
 	)
-	bot.sendText(ctx, config, chatID, text, keyboard)
+	bot.sendMenuText(ctx, config, chatID, text, keyboard)
 }
 
 func (bot *telegramBot) sendDeviceStatus(ctx context.Context, config telegramRuntimeConfig, chatID int64, onlyID string) {
@@ -838,8 +845,12 @@ func (bot *telegramBot) sendDeviceStatus(ctx context.Context, config telegramRun
 		} else {
 			lines = append(lines, "设备：在线 · "+strings.ToUpper(firstNonEmpty(stored.DeviceBackend, "AT")))
 			if snapshot := entry.Snapshot; snapshot != nil {
+				customNumber := ""
 				associationNumber := ""
 				if snapshot.ICCID != "" {
+					if policy, policyErr := bot.server.store.CardPolicy(ctx, snapshot.ICCID); policyErr == nil {
+						customNumber = policy.CustomPhoneNumber
+					}
 					if association, associationErr := bot.server.store.PhoneAssociation(ctx, snapshot.ICCID); associationErr == nil {
 						associationNumber = association.Number
 					}
@@ -849,7 +860,7 @@ func (bot *telegramBot) sendDeviceStatus(ctx context.Context, config telegramRun
 					"IMEI："+firstNonEmpty(snapshot.IMEI, stored.ModemIMEI, "--"),
 					"ICCID："+firstNonEmpty(snapshot.ICCID, "--"),
 					"IMSI："+firstNonEmpty(snapshot.IMSI, "--"),
-					"号码："+resolveTelegramPhoneNumber(associationNumber, wfcState, snapshot),
+					"号码："+resolveTelegramPhoneNumber(customNumber, associationNumber, wfcState, snapshot),
 					"原运营商："+telegramSnapshotHomeCarrier(snapshot),
 					"当前网络："+telegramCurrentNetwork(snapshot),
 					"蜂窝模式："+map[bool]string{true: "飞行模式", false: "开启"}[snapshot.FlightMode],
@@ -876,10 +887,13 @@ func (bot *telegramBot) sendDeviceStatus(ctx context.Context, config telegramRun
 		bot.sendText(ctx, config, chatID, "未找到设备 "+onlyID, nil)
 		return
 	}
-	bot.sendText(ctx, config, chatID, strings.Join(blocks, "\n\n"), bot.homeKeyboard())
+	bot.sendMenuText(ctx, config, chatID, strings.Join(blocks, "\n\n"), bot.homeKeyboard())
 }
 
-func resolveTelegramPhoneNumber(associationNumber string, state *vowifi.State, snapshot *device.Snapshot) string {
+func resolveTelegramPhoneNumber(customNumber, associationNumber string, state *vowifi.State, snapshot *device.Snapshot) string {
+	if usableTelegramPhoneNumber(customNumber) {
+		return strings.TrimSpace(customNumber)
+	}
 	if usableTelegramPhoneNumber(associationNumber) {
 		return strings.TrimSpace(associationNumber)
 	}
@@ -1095,7 +1109,7 @@ func (bot *telegramBot) sendESIMProfiles(ctx context.Context, config telegramRun
 		telegramButton("⬅️ 设备列表", "menu:devices"),
 		telegramButton("🏠 主菜单", "menu:home"),
 	})
-	bot.sendText(ctx, config, chatID, strings.Join(lines, "\n"), telegramKeyboard(rows...))
+	bot.sendMenuText(ctx, config, chatID, strings.Join(lines, "\n"), telegramKeyboard(rows...))
 }
 
 func (bot *telegramBot) confirmESIMSwitch(ctx context.Context, config telegramRuntimeConfig, chatID, adminID int64, deviceID, iccid string) {
@@ -2138,12 +2152,7 @@ func (bot *telegramBot) handleVoWiFi(ctx context.Context, config telegramRuntime
 	}
 	operation = strings.ToLower(strings.TrimSpace(operation))
 	if operation == "status" {
-		state, stateErr := bot.server.vowifi.State(deviceID)
-		if stateErr != nil {
-			bot.sendText(ctx, config, chatID, "读取 VoWiFi 状态失败："+stateErr.Error(), nil)
-			return
-		}
-		bot.sendText(ctx, config, chatID, formatTelegramVoWiFiState(state), nil)
+		bot.sendVoWiFiMenu(ctx, config, chatID, adminID, deviceID)
 		return
 	}
 	var state vowifi.State
@@ -2373,7 +2382,7 @@ func (bot *telegramBot) call(ctx context.Context, config telegramRuntimeConfig, 
 	if err != nil {
 		return err
 	}
-	client, err := restrictedHTTPClient(ctx, 10*time.Second, config.Proxy)
+	client, err := bot.httpClient(ctx, config.Proxy)
 	if err != nil {
 		return err
 	}
@@ -2407,6 +2416,25 @@ func (bot *telegramBot) call(ctx context.Context, config telegramRuntimeConfig, 
 	return nil
 }
 
+func (bot *telegramBot) httpClient(ctx context.Context, proxy string) (*http.Client, error) {
+	proxy = strings.TrimSpace(proxy)
+	bot.clientMu.Lock()
+	defer bot.clientMu.Unlock()
+	if bot.client != nil && bot.clientProxy == proxy {
+		return bot.client, nil
+	}
+	client, err := persistentRestrictedHTTPClient(ctx, 10*time.Second, proxy)
+	if err != nil {
+		return nil, err
+	}
+	if bot.client != nil {
+		bot.client.CloseIdleConnections()
+	}
+	bot.clientProxy = proxy
+	bot.client = client
+	return client, nil
+}
+
 func (bot *telegramBot) notificationDestinationContext(ctx context.Context) context.Context {
 	if bot.server == nil {
 		return ctx
@@ -2415,7 +2443,30 @@ func (bot *telegramBot) notificationDestinationContext(ctx context.Context) cont
 }
 
 func (bot *telegramBot) sendText(ctx context.Context, config telegramRuntimeConfig, chatID int64, text string, replyMarkup any) error {
-	target := config.ChatID
+	method, payload := telegramTextRequest("sendMessage", config.ChatID, chatID, 0, text, replyMarkup)
+	requestContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	return bot.call(requestContext, config, method, payload, nil)
+}
+
+func (bot *telegramBot) sendMenuText(ctx context.Context, config telegramRuntimeConfig, chatID int64, text string, replyMarkup any) error {
+	messageID, _ := ctx.Value(telegramMenuMessageContextKey{}).(int64)
+	if messageID == 0 {
+		return bot.sendText(ctx, config, chatID, text, replyMarkup)
+	}
+	method, payload := telegramTextRequest("editMessageText", config.ChatID, chatID, messageID, text, replyMarkup)
+	requestContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+	err := bot.call(requestContext, config, method, payload, nil)
+	cancel()
+	if err == nil || strings.Contains(strings.ToLower(err.Error()), "message is not modified") {
+		return nil
+	}
+	bot.warn("edit Telegram menu message", err)
+	return bot.sendText(ctx, config, chatID, text, replyMarkup)
+}
+
+func telegramTextRequest(method, configuredChatID string, chatID, messageID int64, text string, replyMarkup any) (string, map[string]any) {
+	target := configuredChatID
 	if chatID != 0 {
 		target = strconv.FormatInt(chatID, 10)
 	}
@@ -2423,12 +2474,13 @@ func (bot *telegramBot) sendText(ctx context.Context, config telegramRuntimeConf
 		"chat_id": target,
 		"text":    truncateTelegramText(text, 3900),
 	}
+	if method == "editMessageText" && messageID != 0 {
+		payload["message_id"] = messageID
+	}
 	if replyMarkup != nil {
 		payload["reply_markup"] = replyMarkup
 	}
-	requestContext, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	return bot.call(requestContext, config, "sendMessage", payload, nil)
+	return method, payload
 }
 
 func (bot *telegramBot) answerCallback(ctx context.Context, config telegramRuntimeConfig, callbackID, text string) error {

--- a/internal/server/telegram_bot_test.go
+++ b/internal/server/telegram_bot_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -68,6 +70,57 @@ func TestTelegramPollingAcceptsFakeIPWithoutWebAccessAllowlist(t *testing.T) {
 	}
 }
 
+func TestTelegramHTTPClientReusesKeepAliveTransportUntilProxyChanges(t *testing.T) {
+	bot := &telegramBot{}
+	first, err := bot.httpClient(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := bot.httpClient(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("Telegram HTTP client was recreated for unchanged configuration")
+	}
+	transport, ok := first.Transport.(*http.Transport)
+	if !ok || transport.DisableKeepAlives || transport.MaxIdleConnsPerHost < 1 {
+		t.Fatalf("Telegram transport does not retain connections: %#v", first.Transport)
+	}
+
+	proxy := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer proxy.Close()
+	third, err := bot.httpClient(context.Background(), proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third == first {
+		t.Fatal("Telegram HTTP client was reused after proxy configuration changed")
+	}
+}
+
+func TestTelegramTextRequestUsesEditForCallbackMenus(t *testing.T) {
+	keyboard := telegramKeyboard([]map[string]string{telegramButton("返回", "menu:home")})
+	method, payload := telegramTextRequest("editMessageText", "-1000", -2000, 42, "菜单", keyboard)
+	if method != "editMessageText" {
+		t.Fatalf("method = %q", method)
+	}
+	if payload["chat_id"] != "-2000" || payload["message_id"] != int64(42) || payload["text"] != "菜单" {
+		t.Fatalf("edit payload = %#v", payload)
+	}
+	if payload["reply_markup"] == nil {
+		t.Fatal("edit payload omitted keyboard")
+	}
+
+	method, payload = telegramTextRequest("sendMessage", "-1000", 0, 0, "新消息", nil)
+	if method != "sendMessage" || payload["chat_id"] != "-1000" {
+		t.Fatalf("send payload = %q %#v", method, payload)
+	}
+	if _, exists := payload["message_id"]; exists {
+		t.Fatalf("send payload unexpectedly contains message_id: %#v", payload)
+	}
+}
+
 func TestParseTelegramCommand(t *testing.T) {
 	command, remainder := parseTelegramCommand("  /sms@vocat_bot EC20 +447700900123 hello world  ")
 	if command != "sms" || remainder != "EC20 +447700900123 hello world" {
@@ -107,10 +160,13 @@ func TestResolveTelegramPhoneNumberPrefersCurrentSIMAssociation(t *testing.T) {
 		ICCID:       snapshot.ICCID,
 		PhoneNumber: "+447386125520",
 	}
-	if got := resolveTelegramPhoneNumber("+447700900123", state, snapshot); got != "+447700900123" {
+	if got := resolveTelegramPhoneNumber("+8613800138000", "+447700900123", state, snapshot); got != "+8613800138000" {
+		t.Fatalf("resolved custom number = %q", got)
+	}
+	if got := resolveTelegramPhoneNumber("", "+447700900123", state, snapshot); got != "+447700900123" {
 		t.Fatalf("resolved association number = %q", got)
 	}
-	if got := resolveTelegramPhoneNumber("", state, snapshot); got != "+447386125520" {
+	if got := resolveTelegramPhoneNumber("", "", state, snapshot); got != "+447386125520" {
 		t.Fatalf("resolved IMS number = %q", got)
 	}
 }
@@ -124,7 +180,7 @@ func TestResolveTelegramPhoneNumberRejectsPlaceholderAndStaleRuntime(t *testing.
 		ICCID:       "previous-card",
 		PhoneNumber: "+447700900123",
 	}
-	if got := resolveTelegramPhoneNumber("", state, snapshot); got != "--" {
+	if got := resolveTelegramPhoneNumber("", "", state, snapshot); got != "--" {
 		t.Fatalf("stale or placeholder number leaked as %q", got)
 	}
 	for _, placeholder := range []string{"00000000000", "1111111111", "+0000000000", "not-a-number"} {


### PR DESCRIPTION
## Summary

- show the configured per-SIM phone number in Telegram device status
- reuse the Telegram HTTP transport so callback actions keep proxy/TLS connections alive
- edit callback-driven menus in place to reduce button latency and message clutter
- keep command responses and action results as separate messages

## Testing

- `go test ./internal/server -run Telegram -count=1`
- `go test ./internal/server ./internal/store -count=1`
- `go vet ./internal/server ./internal/store`
- `git diff --check`
- `cd web && npm ci --no-audit --no-fund && npm run build`
- ARM64 production build deployed and tested on OpenStick 410
- `/healthz` returned `{"status":"ok"}`
- `/readyz` returned `{"status":"ready"}`
- rollback was executed successfully, followed by a verified redeployment

## Notes

The full Go suite passes except `internal/qmiport/TestLeaseReopensReplacedDeviceNode` on Windows, where Windows prevents removing a temporary device node while its file handle is open. The failure is pre-existing and unrelated to these Telegram files.

Closes #91


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Telegram menu interactions now update existing messages when possible, with automatic fallback to sending a new message.
  - VoWiFi status returns users to the interactive menu for smoother navigation.
  - Device status now prioritizes configured policy phone numbers when displaying information.
  - Telegram connectivity is more efficient and reliable through connection reuse, including proper handling when proxy settings change.
  - Updated wording for the Advanced Tools menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->