### PR TITLE
fix(pcsc): match readers after USB path changes

### DIFF
--- a/internal/server/device_api.go
+++ b/internal/server/device_api.go
@@ -16,6 +16,7 @@ import (
 	"vocat/internal/device"
 	"vocat/internal/i18n"
 	"vocat/internal/modem"
+	"vocat/internal/pcsc"
 	"vocat/internal/store"
 	"vocat/internal/vowifi"
 	vowifiruntime "vocat/internal/vowifi/runtime"
@@ -1924,6 +1925,11 @@ func physicalMatchesConfig(entry device.Device, config store.Device) bool {
 		// subsequent discovery returns the resolved device path. Keep checking
 		// the selected AT/QMI nodes instead of rejecting a modem whose physical
 		// path spelling changed but whose control plane is unchanged.
+	}
+	if candidate.HardwareKind == pcsc.HardwareKind && config.ControlDevice != "" && candidate.ReaderName != "" {
+		if config.ControlDevice == candidate.ReaderName {
+			return true
+		}
 	}
 	// Control and serial device nodes are allocation-order dependent. They are
 	// only legacy fallbacks when no physical USB path or readable IMEI exists.


### PR DESCRIPTION
## Summary

- Fall back to the stable PC/SC reader name when a configured reader's USB topology path changes after reboot or hotplug.
- Keep the fallback limited to PC/SC hardware and require an exact reader-name match, so AT/QMI devices and different readers are unaffected.
- Restore the configured reader's eUICC inventory, profile listing, and profile actions instead of returning the offline/empty state.

## Root cause

The saved USB path can change (for example, `2-2.1` to `1-2.1`) while pcscd keeps the same reader name. `physicalMatchesConfig` previously checked only the USB path for PC/SC readers, so the server classified the configured reader as physically absent before `ESIMInventory` ran.

## Validation

- Live old eSTK card: standard ISD-R SELECT succeeded; inventory returned 1 eUICC, 1 profile, and an EID.
- Verified the UI changed from "No eUICC detected" to the eUICC/profile view.
- `go test ./internal/server -run 'TestPhysicalMatchesConfig|TestDevice' -count=1`
- `go test ./internal/server ./internal/pcsc ./internal/device -count=1`
- `go vet ./...`
- `go build ./cmd/vocat`
- Frontend build and tests passed.

This PR intentionally contains only the production source change: 1 file, 6 additions, no test files or generated artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device detection for PCSC devices configured with a control-device reader name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->