### PR TITLE
fix(sms): stop repeated multipart SMS notifications

### DIFF
--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -697,9 +697,11 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 				"message_reference":  message.MessageReference,
 				"delivery_status":    message.DeliveryStatus,
 				"data_coding_scheme": message.DataCodingScheme,
-				// Mark 410 rows so completed multipart messages retain their durable
-				// id when its modem storage is decoded again on the next poll.
-				"keep_durable_id_on_rescan": store.NormalizeDeviceType(config.DeviceType) == store.DeviceTypeWiFi410,
+				// Every AT modem periodically rescans persistent SMS storage. Keep a
+				// completed multipart row's cursor stable when a decoder presents a
+				// segment differently on a later pass, otherwise notification
+				// providers can treat the old message as newly inserted.
+				"keep_durable_id_on_rescan": true,
 			})
 			saveResult, saveErr := s.store.SaveSMSMessageWithResult(ctx, store.SMSMessage{
 				MessageID:     messageID,
@@ -742,10 +744,19 @@ func modemSMSMessageID(message device.SMSMessage, modemIMEI, deviceID, peer stri
 	)
 	if message.Concat != nil && message.Concat.Total > 1 {
 		// A segment of a carrier-split long SMS. Address the whole message
-		// with a stable id so SaveSMSMessage folds every segment into one
-		// progressively merged row instead of one row per segment.
+		// with a storage-generation id so SaveSMSMessage folds every segment
+		// into one row without colliding with an older message that reused the
+		// same UDH reference. SM and ME can expose duplicate copies of the same
+		// slots, so the generation uses the first segment index, not storage.
+		source := "cellular_at"
+		if message.Concat.Sequence > 0 {
+			baseIndex := message.Index - (message.Concat.Sequence - 1)
+			if baseIndex >= 0 {
+				source = fmt.Sprintf("cellular_at:%d", baseIndex)
+			}
+		}
 		messageID = store.StableConcatMessageID(
-			"cellular_at", modemIMEI, deviceID, peer,
+			source, modemIMEI, deviceID, peer,
 			message.Concat.Reference, message.Concat.Total,
 		)
 	}

--- a/internal/server/sms_api_test.go
+++ b/internal/server/sms_api_test.go
@@ -238,6 +238,67 @@ func TestSyncModemSMSLogsMultipartMessageOnlyOnceAcrossStoragesAndPolls(t *testi
 	}
 }
 
+func TestSyncModemSMSSeparatesReusedConcatReferencesWithoutCursorChurn(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	const (
+		deviceID = "ec20-1"
+		imei     = "867394042309830"
+		peer     = "+447700900123"
+	)
+	if err := database.UpsertDevice(ctx, store.Device{
+		ID: deviceID, Name: "EC20", DeviceType: store.DeviceTypePCIeEC20EC25,
+		ModemIMEI: imei, SMSEnabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	receivedAt := time.Unix(1_700_000_000, 0).UTC()
+	part := func(index, sequence int, body string) device.SMSMessage {
+		return device.SMSMessage{
+			Index: index, Storage: "SM", StorageStatus: device.SMSStatusReceivedUnread,
+			Direction: device.SMSDirectionReceived, From: peer, Text: body,
+			Encoding: device.SMSEncodingGSM7PDU, ServiceCenterTimestamp: &receivedAt,
+			Concat: &device.SMSConcatInfo{Reference: 7, Total: 2, Sequence: sequence},
+			RawPDU: body,
+		}
+	}
+	messages := []device.SMSMessage{
+		part(20, 1, "old-a "), part(21, 2, "old-b"),
+		part(42, 1, "new-a "), part(43, 2, "new-b"),
+	}
+	server := &Server{
+		store: database, logger: regionTestLogger(),
+		devices: fakeDeviceController{
+			entry: device.Device{ID: deviceID, Discovered: true,
+				Snapshot: &device.Snapshot{DeviceID: deviceID, IMEI: imei, IMSI: "23433"}},
+			smsMessages: messages,
+		},
+	}
+
+	server.syncModemSMS(ctx, deviceID)
+	first, err := database.ListSMSMessages(ctx, store.SMSFilter{DeviceID: deviceID})
+	if err != nil || len(first) != 2 {
+		t.Fatalf("first sync messages = %#v, %v", first, err)
+	}
+	latest, err := database.LatestSMSMessageID(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.syncModemSMS(ctx, deviceID)
+	second, err := database.ListSMSMessages(ctx, store.SMSFilter{DeviceID: deviceID})
+	if err != nil || len(second) != 2 {
+		t.Fatalf("second sync messages = %#v, %v", second, err)
+	}
+	fresh, err := database.ListInboundSMSAfterID(ctx, latest, 10)
+	if err != nil || len(fresh) != 0 {
+		t.Fatalf("notification rows after repeated scan = %#v, %v", fresh, err)
+	}
+}
+
 func TestDeleteSMSRemovesModemCopyBeforeDatabaseRow(t *testing.T) {
 	ctx := context.Background()
 	database, err := store.Open(ctx, ":memory:")

--- a/internal/server/sms_notifications.go
+++ b/internal/server/sms_notifications.go
@@ -104,6 +104,10 @@ func (s *Server) runSMSNotificationChannel(ctx context.Context, channel string) 
 				}
 			} else {
 				for _, message := range messages {
+					if !store.ConcatSMSReadyToNotify(message.MessageID, message.Extra) {
+						cursor = message.ID
+						continue
+					}
 					notification := s.newSMSNotification(ctx, message)
 					if sendErr := sendSMSNotification(s.notificationDestinationContext(ctx), channel, config, notification); sendErr != nil {
 						if sendErr.Error() != lastError || time.Since(lastErrorAt) >= time.Minute {


### PR DESCRIPTION
## Summary

- distinguish stored multipart SMS generations when carriers reuse the same UDH reference
- keep completed multipart message cursors stable across AT modem rescans
- skip incomplete multipart rows in Bark, email, Pushplus, webhook, WeCom, and Lark dispatchers
- add a regression test covering reused references and repeated modem scans

## Root cause

The modem SMS poller used only the sender, hardware identity, UDH reference, and part count as the multipart message key. UDH references are reused, so multiple historical messages still present in modem storage could collapse into one row. Each poll then replaced that row, assigned a new durable ID, and notification providers treated the stored message as newly received.

## Validation

- `go test ./internal/store ./internal/server`
- `npm run build`
- `npm test`
- live EC20 validation: repeated storage scans and a service restart kept the SMS cursor stable and produced no duplicate Bark notification

## Full test note

`go test ./...` passes all packages except the existing Windows-only `internal/qmiport` device-node replacement test, which cannot remove an open temporary file on Windows. The changed server/store packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multipart SMS messages across all modem types.
  * Prevented separate messages from being merged when they reuse concatenation references.
  * Preserved message IDs during rescans to avoid duplicate records and notifications.
  * Ensured notification processing skips incomplete inbound messages and continues with later messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->