### PR TITLE
Fix duplicate notifications for multipart SMS

### DIFF
--- a/internal/server/sms_notifications.go
+++ b/internal/server/sms_notifications.go
@@ -104,6 +104,13 @@ func (s *Server) runSMSNotificationChannel(ctx context.Context, channel string) 
 				}
 			} else {
 				for _, message := range messages {
+					if !smsNotificationReady(message) {
+						// Advance past an incomplete carrier-split long SMS. Once every
+						// segment arrives, storage creates a new completed row and it
+						// returns through this cursor as one notification.
+						cursor = message.ID
+						continue
+					}
 					notification := s.newSMSNotification(ctx, message)
 					if sendErr := sendSMSNotification(s.notificationDestinationContext(ctx), channel, config, notification); sendErr != nil {
 						if sendErr.Error() != lastError || time.Since(lastErrorAt) >= time.Minute {
@@ -121,6 +128,10 @@ func (s *Server) runSMSNotificationChannel(ctx context.Context, channel string) 
 			return
 		}
 	}
+}
+
+func smsNotificationReady(message store.SMSMessage) bool {
+	return store.ConcatSMSReadyToNotify(message.MessageID, message.Extra)
 }
 
 func (s *Server) smsNotificationConfig(ctx context.Context, channel string) (map[string]any, bool, error) {

--- a/internal/server/sms_notifications_test.go
+++ b/internal/server/sms_notifications_test.go
@@ -1,10 +1,28 @@
 package server
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
+
+	"vocat/internal/store"
 )
+
+func TestSMSNotificationReadyWaitsForAllLongSMSParts(t *testing.T) {
+	partial := store.SMSMessage{
+		MessageID: "concat:cellular_at:imei:sender:1:2",
+		Extra:     json.RawMessage(`{"concat_complete":false}`),
+	}
+	if smsNotificationReady(partial) {
+		t.Fatal("incomplete long SMS is ready for notification")
+	}
+
+	partial.Extra = json.RawMessage(`{"concat_complete":true}`)
+	if !smsNotificationReady(partial) {
+		t.Fatal("complete long SMS is not ready for notification")
+	}
+}
 
 func TestSMSNotificationTextMatchesUserFacingTemplate(t *testing.T) {
 	location := time.FixedZone("UTC+8", 8*60*60)


### PR DESCRIPTION
## Summary

  Fix duplicate Bark notifications for multipart SMS messages.

  Long SMS messages are received in multiple carrier segments. The notification
  dispatcher now advances past incomplete segments and sends one notification
  after all segments are merged into the complete message.

  ## Changes

  - Apply multipart-SMS readiness checks to all SMS notification channels,
  including Bark
  - Advance the notification cursor for incomplete segments
  - Add regression coverage for incomplete and completed concatenated SMS
  messages

  ## Validation

  - Verified the notification readiness behavior for partial and completed
  multipart SMS records
  - `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate or premature SMS notifications when messages arrive in multiple parts.
  - Notifications now wait until all SMS parts are fully received before being sent.
  - Incomplete message fragments are safely skipped until the completed message is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->