### PR TITLE
fix(openwrt): stabilize EC20 VoWiFi, SMS and notifications on MT3000

### DIFF
--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -42,6 +42,13 @@ import (
 
 const flightModeTransitionTimeout = 45 * time.Second
 
+func startupFlightModeContext(parent context.Context) (context.Context, context.CancelFunc) {
+	// Startup has a short database/configuration deadline. CFUN transitions on
+	// EC20 can legitimately outlive it while USB disappears and re-enumerates,
+	// so retain startup values without inheriting that deadline.
+	return context.WithTimeout(context.WithoutCancel(parent), flightModeTransitionTimeout)
+}
+
 func main() {
 	logs := loghub.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}), 2000)
 	logger := slog.New(logs)
@@ -464,7 +471,7 @@ func restoreDefaultCellularRadios(
 				continue
 			}
 		}
-		restoreContext, cancel := context.WithTimeout(ctx, flightModeTransitionTimeout)
+		restoreContext, cancel := startupFlightModeContext(ctx)
 		_, err = manager.SetFlight(restoreContext, entry.ID, false)
 		cancel()
 		if err != nil {
@@ -759,9 +766,15 @@ func protectVoWiFiStartupRadioWithRetry(
 	attempts int,
 	delay time.Duration,
 ) error {
+	if attempts <= 0 {
+		return nil
+	}
+	retryBudget := time.Duration(attempts)*flightModeTransitionTimeout + time.Duration(attempts-1)*delay
+	retryContext, cancelRetry := context.WithTimeout(context.WithoutCancel(ctx), retryBudget)
+	defer cancelRetry()
 	var lastErr error
 	for attempt := 0; attempt < attempts; attempt++ {
-		flightContext, cancel := context.WithTimeout(ctx, flightModeTransitionTimeout)
+		flightContext, cancel := context.WithTimeout(retryContext, flightModeTransitionTimeout)
 		_, lastErr = manager.SetFlight(flightContext, physicalID, true)
 		cancel()
 		if lastErr == nil {
@@ -772,11 +785,11 @@ func protectVoWiFiStartupRadioWithRetry(
 		}
 		timer := time.NewTimer(delay)
 		select {
-		case <-ctx.Done():
+		case <-retryContext.Done():
 			if !timer.Stop() {
 				<-timer.C
 			}
-			return errors.Join(lastErr, ctx.Err())
+			return errors.Join(lastErr, retryContext.Err())
 		case <-timer.C:
 		}
 	}

--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -40,13 +40,18 @@ import (
 	"vocat/web"
 )
 
-const flightModeTransitionTimeout = 45 * time.Second
+const (
+	flightModeTransitionTimeout = 45 * time.Second
+	deviceStartupTimeout        = 4 * time.Minute
+)
+
+func deviceStartupContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), deviceStartupTimeout)
+}
 
 func startupFlightModeContext(parent context.Context) (context.Context, context.CancelFunc) {
-	// Startup has a short database/configuration deadline. CFUN transitions on
-	// EC20 can legitimately outlive it while USB disappears and re-enumerates,
-	// so retain startup values without inheriting that deadline.
-	return context.WithTimeout(context.WithoutCancel(parent), flightModeTransitionTimeout)
+	// Bound each EC20 CFUN transition inside the larger device-startup budget.
+	return context.WithTimeout(parent, flightModeTransitionTimeout)
 }
 
 func main() {
@@ -220,14 +225,20 @@ func run(logger *slog.Logger, logs *loghub.Hub) error {
 	if err != nil {
 		return fmt.Errorf("create device manager: %w", err)
 	}
-	if err := deviceManager.Start(startupContext); err != nil {
+	// Device startup has a separate budget because EC20 CFUN transitions can
+	// temporarily remove the USB serial transport, and OpenStick 410 deliberately
+	// delays its persisted VoWiFi policy after a cold boot. Do not reuse the short
+	// database/configuration deadline for this hardware lifecycle.
+	deviceStartupContext, cancelDeviceStartup := deviceStartupContext(startupContext)
+	defer cancelDeviceStartup()
+	if err := deviceManager.Start(deviceStartupContext); err != nil {
 		logger.Warn("device discovery is not available at startup", "error", err)
 	}
-	if err := provisionDiscoveredDevices(startupContext, database, deviceManager); err != nil {
+	if err := provisionDiscoveredDevices(deviceStartupContext, database, deviceManager); err != nil {
 		logger.Warn("automatic first-run device provisioning failed", "error", err)
 	}
-	configureDeviceBackends(startupContext, logger, database, deviceManager)
-	restoreDefaultCellularRadios(startupContext, logger, database, deviceManager)
+	configureDeviceBackends(deviceStartupContext, logger, database, deviceManager)
+	restoreDefaultCellularRadios(deviceStartupContext, logger, database, deviceManager)
 	defer func() {
 		stopContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -249,7 +260,7 @@ func run(logger *slog.Logger, logs *loghub.Hub) error {
 	var onIncomingCall func(context.Context, ims.ReceivedCall) error
 
 	vowifiManager, err := configureVoWiFiRuntime(
-		startupContext,
+		deviceStartupContext,
 		logger,
 		database,
 		deviceManager,
@@ -770,7 +781,7 @@ func protectVoWiFiStartupRadioWithRetry(
 		return nil
 	}
 	retryBudget := time.Duration(attempts)*flightModeTransitionTimeout + time.Duration(attempts-1)*delay
-	retryContext, cancelRetry := context.WithTimeout(context.WithoutCancel(ctx), retryBudget)
+	retryContext, cancelRetry := context.WithTimeout(ctx, retryBudget)
 	defer cancelRetry()
 	var lastErr error
 	for attempt := 0; attempt < attempts; attempt++ {

--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -381,9 +381,13 @@ func run(logger *slog.Logger, logs *loghub.Hub) error {
 
 	select {
 	case err := <-serverError:
+		cancelDeviceStartup()
 		_ = protocolMux.Close()
 		return err
 	case <-signalContext.Done():
+		// Stop delayed OpenStick 410 startup work before the deferred VoWiFi
+		// manager shutdown begins, so it cannot enqueue a late enable request.
+		cancelDeviceStartup()
 		logger.Info("shutdown signal received")
 	}
 	// Long-lived SSE and polling handlers use this context. Stop them before

--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -40,6 +40,8 @@ import (
 	"vocat/web"
 )
 
+const flightModeTransitionTimeout = 45 * time.Second
+
 func main() {
 	logs := loghub.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}), 2000)
 	logger := slog.New(logs)
@@ -462,7 +464,7 @@ func restoreDefaultCellularRadios(
 				continue
 			}
 		}
-		restoreContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+		restoreContext, cancel := context.WithTimeout(ctx, flightModeTransitionTimeout)
 		_, err = manager.SetFlight(restoreContext, entry.ID, false)
 		cancel()
 		if err != nil {
@@ -759,7 +761,7 @@ func protectVoWiFiStartupRadioWithRetry(
 ) error {
 	var lastErr error
 	for attempt := 0; attempt < attempts; attempt++ {
-		flightContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+		flightContext, cancel := context.WithTimeout(ctx, flightModeTransitionTimeout)
 		_, lastErr = manager.SetFlight(flightContext, physicalID, true)
 		cancel()
 		if lastErr == nil {
@@ -1132,7 +1134,7 @@ func enforceDefaultSafeCardPolicy(
 		logger.Warn("default card policy: read policy", "iccid", iccid, "error", err)
 		return
 	}
-	flightContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+	flightContext, cancel := context.WithTimeout(ctx, flightModeTransitionTimeout)
 	_, err := manager.SetFlight(flightContext, physicalID, true)
 	cancel()
 	if err != nil {
@@ -1250,7 +1252,7 @@ func reconcileCardPolicies(
 			state, stateErr := vowifiManager.State(config.ID)
 			if policy.VoWiFiEnabled {
 				if !entry.Snapshot.FlightMode {
-					flightContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+					flightContext, cancel := context.WithTimeout(ctx, flightModeTransitionTimeout)
 					_, _ = manager.SetFlight(flightContext, entry.ID, true)
 					cancel()
 				}
@@ -1272,7 +1274,7 @@ func reconcileCardPolicies(
 				continue
 			}
 			if policy.AirplaneEnabled != entry.Snapshot.FlightMode {
-				flightContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+				flightContext, cancel := context.WithTimeout(ctx, flightModeTransitionTimeout)
 				_, _ = manager.SetFlight(flightContext, entry.ID, policy.AirplaneEnabled)
 				cancel()
 			}
@@ -1322,7 +1324,7 @@ func enforceCardRegion(
 	}
 	if reason := device.RegionBlockReason(imsi); reason != "" {
 		if !snapshot.FlightMode {
-			flightContext, cancelFlight := context.WithTimeout(ctx, 30*time.Second)
+			flightContext, cancelFlight := context.WithTimeout(ctx, flightModeTransitionTimeout)
 			_, err := manager.SetFlight(flightContext, id, true)
 			cancelFlight()
 			if err != nil && ctx.Err() == nil {

--- a/internal/device/controls.go
+++ b/internal/device/controls.go
@@ -306,6 +306,8 @@ func (manager *Manager) SetFlight(
 	}
 
 	changed := target != previous
+	current := previous
+	currentKnown := false
 	if changed {
 		if enabled {
 			// Entering RF-off tears down the packet service. Forget the previous
@@ -319,25 +321,35 @@ func (manager *Manager) SetFlight(
 			client,
 			fmt.Sprintf("AT+CFUN=%d", target),
 		); err != nil {
+			recoveredClient, recoveredMode, recoveryErr := manager.recoverOperatingModeAfterTransportLoss(
+				ctx, id, state, client, target, err,
+			)
+			if recoveryErr != nil {
+				manager.setResult(id, state, nil, recoveryErr)
+				return FlightResult{
+					PreviousMode: previous,
+					CurrentMode:  previous,
+					FlightMode:   isRadioOffMode(previous),
+					RadioOff:     isRadioOffMode(previous),
+				}, recoveryErr
+			}
+			client = recoveredClient
+			current = recoveredMode
+			currentKnown = true
+		}
+	}
+	if !currentKnown {
+		current, err = manager.readOperatingMode(ctx, client)
+		if err != nil {
 			manager.setResult(id, state, nil, err)
 			return FlightResult{
 				PreviousMode: previous,
-				CurrentMode:  previous,
-				FlightMode:   isRadioOffMode(previous),
-				RadioOff:     isRadioOffMode(previous),
+				CurrentMode:  target,
+				Changed:      changed,
+				FlightMode:   isRadioOffMode(target),
+				RadioOff:     isRadioOffMode(target),
 			}, err
 		}
-	}
-	current, err := manager.readOperatingMode(ctx, client)
-	if err != nil {
-		manager.setResult(id, state, nil, err)
-		return FlightResult{
-			PreviousMode: previous,
-			CurrentMode:  target,
-			Changed:      changed,
-			FlightMode:   isRadioOffMode(target),
-			RadioOff:     isRadioOffMode(target),
-		}, err
 	}
 	if !enabled && !isRadioOffMode(current) {
 		state.preFlightMode = nil
@@ -351,6 +363,84 @@ func (manager *Manager) SetFlight(
 		FlightMode:   isRadioOffMode(current),
 		RadioOff:     isRadioOffMode(current),
 	}, nil
+}
+
+// recoverOperatingModeAfterTransportLoss handles modems that commit CFUN and
+// then briefly disappear from USB before returning the final AT response. It
+// is deliberately limited to poisoned transports and only reports success
+// after a fresh session reads back the requested mode.
+func (manager *Manager) recoverOperatingModeAfterTransportLoss(
+	ctx context.Context,
+	id string,
+	state *managedDevice,
+	client modem.Client,
+	target int,
+	commandErr error,
+) (modem.Client, int, error) {
+	poisoned, ok := client.(modem.PoisonedClient)
+	if !ok || !poisoned.Poisoned() {
+		return nil, 0, commandErr
+	}
+
+	_ = client.Close()
+	state.client = nil
+
+	recoveryCtx, cancel := manager.withTimeout(ctx, manager.longTimeout)
+	defer cancel()
+	lastErr := commandErr
+	for {
+		manager.rediscoverCandidateForRecovery(recoveryCtx, id, state)
+		reopened, err := manager.clientLocked(recoveryCtx, state, manager.candidateFor(state))
+		if err == nil {
+			mode, readErr := manager.readOperatingMode(recoveryCtx, reopened)
+			if readErr == nil && mode == target {
+				return reopened, mode, nil
+			}
+			if readErr != nil {
+				lastErr = readErr
+			} else {
+				lastErr = fmt.Errorf("modem operating mode is %d, want %d", mode, target)
+			}
+			if poisoned, ok := reopened.(modem.PoisonedClient); ok && poisoned.Poisoned() {
+				_ = reopened.Close()
+				state.client = nil
+			}
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-recoveryCtx.Done():
+			return nil, 0, fmt.Errorf(
+				"%w; confirm AT+CFUN=%d after transport recovery: %v",
+				commandErr, target, lastErr,
+			)
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func (manager *Manager) rediscoverCandidateForRecovery(
+	ctx context.Context,
+	id string,
+	state *managedDevice,
+) {
+	candidates, err := manager.discoverer.Discover(ctx)
+	if err != nil {
+		return
+	}
+	for _, candidate := range candidates {
+		if candidate.ID != id {
+			continue
+		}
+		manager.mu.Lock()
+		if manager.devices[id] == state {
+			state.candidate = candidate
+			state.discovered = true
+		}
+		manager.mu.Unlock()
+		return
+	}
 }
 
 func (manager *Manager) readOperatingMode(

--- a/internal/device/controls.go
+++ b/internal/device/controls.go
@@ -321,7 +321,7 @@ func (manager *Manager) SetFlight(
 			client,
 			fmt.Sprintf("AT+CFUN=%d", target),
 		); err != nil {
-			recoveredClient, recoveredMode, recoveryErr := manager.recoverOperatingModeAfterTransportLoss(
+			_, recoveredMode, recoveryErr := manager.recoverOperatingModeAfterTransportLoss(
 				ctx, id, state, client, target, err,
 			)
 			if recoveryErr != nil {
@@ -333,7 +333,6 @@ func (manager *Manager) SetFlight(
 					RadioOff:     isRadioOffMode(previous),
 				}, recoveryErr
 			}
-			client = recoveredClient
 			current = recoveredMode
 			currentKnown = true
 		}
@@ -341,14 +340,21 @@ func (manager *Manager) SetFlight(
 	if !currentKnown {
 		current, err = manager.readOperatingMode(ctx, client)
 		if err != nil {
-			manager.setResult(id, state, nil, err)
-			return FlightResult{
-				PreviousMode: previous,
-				CurrentMode:  target,
-				Changed:      changed,
-				FlightMode:   isRadioOffMode(target),
-				RadioOff:     isRadioOffMode(target),
-			}, err
+			recoveredClient, recoveredMode, recoveryErr := manager.recoverOperatingModeAfterTransportLoss(
+				ctx, id, state, client, target, err,
+			)
+			if recoveryErr != nil {
+				manager.setResult(id, state, nil, recoveryErr)
+				return FlightResult{
+					PreviousMode: previous,
+					CurrentMode:  target,
+					Changed:      changed,
+					FlightMode:   isRadioOffMode(target),
+					RadioOff:     isRadioOffMode(target),
+				}, recoveryErr
+			}
+			client = recoveredClient
+			current = recoveredMode
 		}
 	}
 	if !enabled && !isRadioOffMode(current) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -183,6 +183,10 @@ type VoWiFiController interface {
 	RequestReconnect(string) (vowifi.State, error)
 }
 
+type VoWiFiSMSSyncController interface {
+	ModemSMSSyncBlocked(string) bool
+}
+
 type VoWiFiMaintenanceController interface {
 	BeginMaintenance(string) error
 	EndMaintenance(string)

--- a/internal/server/settings_api.go
+++ b/internal/server/settings_api.go
@@ -1273,6 +1273,10 @@ func resolveNotificationAddresses(ctx context.Context, host string, allowLocal b
 
 var notificationFakeIPNetworks = []netip.Prefix{
 	netip.MustParsePrefix("198.18.0.0/15"),
+	// Mihomo/Clash can synthesize ULA addresses alongside its RFC 2544
+	// IPv4 Fake-IP range. These addresses are consumed by the local TUN DNS
+	// interceptor and do not identify a LAN service.
+	netip.MustParsePrefix("fdfe:dcba:9876::/48"),
 }
 
 var blockedNotificationDestinationNetworks = []netip.Prefix{

--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -852,12 +852,11 @@ func shouldDeferModemSMSSync(state vowifi.State, stateErr error) bool {
 	if stateErr != nil || !state.Enabled {
 		return false
 	}
-	// An enabled VoWiFi policy keeps cellular RF off. Even after IMS reaches
-	// SMSReady, EC20 AT+CMGL can block until its command timeout or close the
-	// serial session, delaying every SMS-page request and competing with SIM/AKA
-	// work. SIP MESSAGE delivery persists live IMS SMS; scan modem storage only
-	// after VoWiFi is disabled or a terminal failure restores cellular radio.
-	return state.Phase != vowifi.PhaseFailed
+	// An enabled VoWiFi policy owns the UICC/AT path, including the interval
+	// between a failure and its automatic retry. EC20 AT+CMGL can hold the device
+	// lock for its full timeout and delay that retry. SIP MESSAGE persists live
+	// IMS SMS; scan modem storage only after the policy is explicitly disabled.
+	return true
 }
 
 // StartSMSSyncLoop periodically persists inbound cellular SMS even when no

--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -617,7 +617,13 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 		// though subsequent live SMS is delivered by SIP MESSAGE.
 		if s.vowifi != nil {
 			state, stateErr := s.vowifi.State(config.ID)
-			if shouldDeferModemSMSSync(state, stateErr) {
+			deferSync := shouldDeferModemSMSSync(state, stateErr)
+			if !deferSync && stateErr == nil && state.Enabled && state.Phase == vowifi.PhaseFailed {
+				if controller, ok := s.vowifi.(VoWiFiSMSSyncController); ok {
+					deferSync = controller.ModemSMSSyncBlocked(config.ID)
+				}
+			}
+			if deferSync {
 				continue
 			}
 		}
@@ -852,11 +858,15 @@ func shouldDeferModemSMSSync(state vowifi.State, stateErr error) bool {
 	if stateErr != nil || !state.Enabled {
 		return false
 	}
-	// An enabled VoWiFi policy owns the UICC/AT path, including the interval
-	// between a failure and its automatic retry. EC20 AT+CMGL can hold the device
-	// lock for its full timeout and delay that retry. SIP MESSAGE persists live
-	// IMS SMS; scan modem storage only after the policy is explicitly disabled.
-	return true
+	// Setup phases own the UICC/AT path. Once IMS SMS is stable, allow the modem
+	// storage catch-up scan. A failed phase is also eligible unless the runtime's
+	// separate busy/retry signal says an automatic recovery currently owns AT.
+	switch state.Phase {
+	case vowifi.PhaseSMSReady, vowifi.PhaseFailed:
+		return false
+	default:
+		return true
+	}
 }
 
 // StartSMSSyncLoop periodically persists inbound cellular SMS even when no

--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -46,7 +46,6 @@ func (s *Server) handleSMSContacts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	deviceID := normalizeSMSDeviceFilter(r.URL.Query().Get("device_id"))
-	s.syncModemSMS(r.Context(), deviceID)
 	filter := s.smsStoreFilter(r.Context(), deviceID, "")
 	filter.Limit = queryLimit(r, 100)
 	contacts, err := s.store.ListSMSContacts(r.Context(), filter)
@@ -88,7 +87,6 @@ func (s *Server) handleSMSThread(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.Method {
 	case http.MethodGet:
-		s.syncModemSMS(r.Context(), deviceID)
 		filter := s.smsStoreFilter(r.Context(), deviceID, modemIMEI)
 		filter.IMSI = imsi
 		filter.Peer = peer
@@ -854,11 +852,12 @@ func shouldDeferModemSMSSync(state vowifi.State, stateErr error) bool {
 	if stateErr != nil || !state.Enabled {
 		return false
 	}
-	// SMSReady is a quiescent runtime state: SIM/AKA setup has finished and
-	// reading stored messages cannot race the eSIM/VoWiFi startup sequence.
-	// Failed is also safe because the orchestrator has restored cellular radio
-	// operation before publishing the terminal failure state.
-	return state.Phase != vowifi.PhaseSMSReady && state.Phase != vowifi.PhaseFailed
+	// An enabled VoWiFi policy keeps cellular RF off. Even after IMS reaches
+	// SMSReady, EC20 AT+CMGL can block until its command timeout or close the
+	// serial session, delaying every SMS-page request and competing with SIM/AKA
+	// work. SIP MESSAGE delivery persists live IMS SMS; scan modem storage only
+	// after VoWiFi is disabled or a terminal failure restores cellular radio.
+	return state.Phase != vowifi.PhaseFailed
 }
 
 // StartSMSSyncLoop periodically persists inbound cellular SMS even when no

--- a/internal/vowifi/runtime/manager.go
+++ b/internal/vowifi/runtime/manager.go
@@ -238,7 +238,7 @@ func (manager *Manager) ModemSMSSyncBlocked(deviceID string) bool {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	item := manager.entries[deviceID]
-	return item != nil && (item.desiredEnabled || item.busy || item.autoRetryPending)
+	return item != nil && (item.busy || item.autoRetryPending)
 }
 
 // RequestEnabled queues an enable or disable transaction and returns
@@ -539,18 +539,25 @@ func (manager *Manager) runOperations(
 		if !shouldRetry && state.Phase != vowifi.PhaseFailed {
 			item.retryFailures = 0
 		}
-		manager.mu.Unlock()
 		if shouldRetry {
-			manager.scheduleAutoRetry(deviceID, item)
+			// Mark the retry pending before releasing the lifecycle lock. This
+			// closes the handoff window in which AT+CMGL could otherwise start
+			// after busy becomes false but before the retry is visible.
+			manager.scheduleAutoRetryLocked(deviceID, item)
 		}
+		manager.mu.Unlock()
 		return
 	}
 }
 
 func (manager *Manager) scheduleAutoRetry(deviceID string, item *entry) {
 	manager.mu.Lock()
+	manager.scheduleAutoRetryLocked(deviceID, item)
+	manager.mu.Unlock()
+}
+
+func (manager *Manager) scheduleAutoRetryLocked(deviceID string, item *entry) {
 	if manager.closed || item.busy || item.autoRetryPending || !item.desiredEnabled {
-		manager.mu.Unlock()
 		return
 	}
 	delay := manager.retryInitial
@@ -567,7 +574,6 @@ func (manager *Manager) scheduleAutoRetry(deviceID string, item *entry) {
 	item.retryFailures++
 	item.autoRetryPending = true
 	manager.wg.Add(1)
-	manager.mu.Unlock()
 
 	manager.logger.Info(
 		"VoWiFi automatic retry scheduled",

--- a/internal/vowifi/runtime/manager.go
+++ b/internal/vowifi/runtime/manager.go
@@ -231,6 +231,16 @@ func (manager *Manager) State(deviceID string) (vowifi.State, error) {
 	return item.orchestrator.State(), nil
 }
 
+// ModemSMSSyncBlocked reports whether the desired VoWiFi lifecycle still owns
+// the modem command path. The HTTP layer consults this signal for PhaseFailed,
+// including the small handoff window before an automatic retry is scheduled.
+func (manager *Manager) ModemSMSSyncBlocked(deviceID string) bool {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	item := manager.entries[deviceID]
+	return item != nil && (item.desiredEnabled || item.busy || item.autoRetryPending)
+}
+
 // RequestEnabled queues an enable or disable transaction and returns
 // immediately. Callers observe progress through State; provider errors are
 // persisted in the orchestrator state instead of being lost with an HTTP

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -507,7 +507,10 @@ acquire_modem_control() {
     [ -x "$MODEM_RECOVERY_SCRIPT" ] || return 0
     mkdir -p "$MODEM_LOCK_DIR" || return 1
     if [ ! -e "$MODEM_LOCK_FILE" ]; then
-        printf '%s\n' lock > "$MODEM_LOCK_FILE" || return 1
+        if ! printf '%s\n' lock > "$MODEM_LOCK_FILE"; then
+            rm -f "$MODEM_LOCK_FILE"
+            return 1
+        fi
         if ! : > "$MODEM_LOCK_OWNER"; then
             rm -f "$MODEM_LOCK_FILE"
             return 1
@@ -521,7 +524,10 @@ release_modem_control() {
 start_service() {
     if ! acquire_modem_control; then
         logger -t vocat "cannot acquire GL.iNet modem recovery lock"
-        return 1
+        # rc.common's rc_procd ignores start_service's return value and would
+        # otherwise submit an empty service definition. Exit before its
+        # unconditional procd_close_service call and preserve the failure status.
+        exit 1
     fi
     procd_open_instance
     procd_set_param command "$PROGRAM" serve

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -499,7 +499,24 @@ USE_PROCD=1
 PROCD_TERM_TIMEOUT=40
 PROGRAM=/opt/vocat/bin/vocat
 ENV_FILE=/etc/vocat/env
+MODEM_RECOVERY_SCRIPT=/usr/bin/modem_network_recover_detection.sh
+MODEM_LOCK_DIR=/var/run/modem
+MODEM_LOCK_FILE=$MODEM_LOCK_DIR/auto_dial_lock
+MODEM_LOCK_OWNER=/var/run/vocat.modem_control_lock
+acquire_modem_control() {
+    [ -x "$MODEM_RECOVERY_SCRIPT" ] || return 0
+    mkdir -p "$MODEM_LOCK_DIR"
+    if [ ! -e "$MODEM_LOCK_FILE" ]; then
+        printf '%s\n' lock > "$MODEM_LOCK_FILE"
+        : > "$MODEM_LOCK_OWNER"
+    fi
+}
+release_modem_control() {
+    [ -e "$MODEM_LOCK_OWNER" ] || return 0
+    rm -f "$MODEM_LOCK_FILE" "$MODEM_LOCK_OWNER"
+}
 start_service() {
+    acquire_modem_control
     procd_open_instance
     procd_set_param command "$PROGRAM" serve
     procd_set_param env VOCAT_DATABASE_PATH=/opt/vocat/data/vocat.db
@@ -513,6 +530,7 @@ start_service() {
     procd_set_param stderr 1
     procd_close_instance
 }
+stop_service() { release_modem_control; }
 service_triggers() { procd_add_reload_trigger vocat; }
 EOF
     chmod 0755 "$OPENWRT_INIT_PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -505,10 +505,13 @@ MODEM_LOCK_FILE=$MODEM_LOCK_DIR/auto_dial_lock
 MODEM_LOCK_OWNER=/var/run/vocat.modem_control_lock
 acquire_modem_control() {
     [ -x "$MODEM_RECOVERY_SCRIPT" ] || return 0
-    mkdir -p "$MODEM_LOCK_DIR"
+    mkdir -p "$MODEM_LOCK_DIR" || return 1
     if [ ! -e "$MODEM_LOCK_FILE" ]; then
-        printf '%s\n' lock > "$MODEM_LOCK_FILE"
-        : > "$MODEM_LOCK_OWNER"
+        printf '%s\n' lock > "$MODEM_LOCK_FILE" || return 1
+        if ! : > "$MODEM_LOCK_OWNER"; then
+            rm -f "$MODEM_LOCK_FILE"
+            return 1
+        fi
     fi
 }
 release_modem_control() {
@@ -516,7 +519,10 @@ release_modem_control() {
     rm -f "$MODEM_LOCK_FILE" "$MODEM_LOCK_OWNER"
 }
 start_service() {
-    acquire_modem_control
+    if ! acquire_modem_control; then
+        logger -t vocat "cannot acquire GL.iNet modem recovery lock"
+        return 1
+    fi
     procd_open_instance
     procd_set_param command "$PROGRAM" serve
     procd_set_param env VOCAT_DATABASE_PATH=/opt/vocat/data/vocat.db
@@ -530,7 +536,7 @@ start_service() {
     procd_set_param stderr 1
     procd_close_instance
 }
-stop_service() { release_modem_control; }
+service_stopped() { release_modem_control; }
 service_triggers() { procd_add_reload_trigger vocat; }
 EOF
     chmod 0755 "$OPENWRT_INIT_PATH"

--- a/scripts/vocat.openwrt.init
+++ b/scripts/vocat.openwrt.init
@@ -7,8 +7,27 @@ PROCD_TERM_TIMEOUT=40
 
 PROGRAM=/opt/vocat/bin/vocat
 ENV_FILE=/etc/vocat/env
+MODEM_RECOVERY_SCRIPT=/usr/bin/modem_network_recover_detection.sh
+MODEM_LOCK_DIR=/var/run/modem
+MODEM_LOCK_FILE=$MODEM_LOCK_DIR/auto_dial_lock
+MODEM_LOCK_OWNER=/var/run/vocat.modem_control_lock
+
+acquire_modem_control() {
+	[ -x "$MODEM_RECOVERY_SCRIPT" ] || return 0
+	mkdir -p "$MODEM_LOCK_DIR"
+	if [ ! -e "$MODEM_LOCK_FILE" ]; then
+		printf '%s\n' lock > "$MODEM_LOCK_FILE"
+		: > "$MODEM_LOCK_OWNER"
+	fi
+}
+
+release_modem_control() {
+	[ -e "$MODEM_LOCK_OWNER" ] || return 0
+	rm -f "$MODEM_LOCK_FILE" "$MODEM_LOCK_OWNER"
+}
 
 start_service() {
+	acquire_modem_control
 	procd_open_instance
 	procd_set_param command "$PROGRAM" serve
 	procd_set_param env VOCAT_DATABASE_PATH=/opt/vocat/data/vocat.db
@@ -23,6 +42,10 @@ start_service() {
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance
+}
+
+stop_service() {
+	release_modem_control
 }
 
 service_triggers() {

--- a/scripts/vocat.openwrt.init
+++ b/scripts/vocat.openwrt.init
@@ -14,10 +14,13 @@ MODEM_LOCK_OWNER=/var/run/vocat.modem_control_lock
 
 acquire_modem_control() {
 	[ -x "$MODEM_RECOVERY_SCRIPT" ] || return 0
-	mkdir -p "$MODEM_LOCK_DIR"
+	mkdir -p "$MODEM_LOCK_DIR" || return 1
 	if [ ! -e "$MODEM_LOCK_FILE" ]; then
-		printf '%s\n' lock > "$MODEM_LOCK_FILE"
-		: > "$MODEM_LOCK_OWNER"
+		printf '%s\n' lock > "$MODEM_LOCK_FILE" || return 1
+		if ! : > "$MODEM_LOCK_OWNER"; then
+			rm -f "$MODEM_LOCK_FILE"
+			return 1
+		fi
 	fi
 }
 
@@ -27,7 +30,10 @@ release_modem_control() {
 }
 
 start_service() {
-	acquire_modem_control
+	if ! acquire_modem_control; then
+		logger -t vocat "cannot acquire GL.iNet modem recovery lock"
+		return 1
+	fi
 	procd_open_instance
 	procd_set_param command "$PROGRAM" serve
 	procd_set_param env VOCAT_DATABASE_PATH=/opt/vocat/data/vocat.db
@@ -44,7 +50,7 @@ start_service() {
 	procd_close_instance
 }
 
-stop_service() {
+service_stopped() {
 	release_modem_control
 }
 

--- a/scripts/vocat.openwrt.init
+++ b/scripts/vocat.openwrt.init
@@ -16,7 +16,10 @@ acquire_modem_control() {
 	[ -x "$MODEM_RECOVERY_SCRIPT" ] || return 0
 	mkdir -p "$MODEM_LOCK_DIR" || return 1
 	if [ ! -e "$MODEM_LOCK_FILE" ]; then
-		printf '%s\n' lock > "$MODEM_LOCK_FILE" || return 1
+		if ! printf '%s\n' lock > "$MODEM_LOCK_FILE"; then
+			rm -f "$MODEM_LOCK_FILE"
+			return 1
+		fi
 		if ! : > "$MODEM_LOCK_OWNER"; then
 			rm -f "$MODEM_LOCK_FILE"
 			return 1
@@ -32,7 +35,10 @@ release_modem_control() {
 start_service() {
 	if ! acquire_modem_control; then
 		logger -t vocat "cannot acquire GL.iNet modem recovery lock"
-		return 1
+		# rc.common's rc_procd ignores start_service's return value and would
+		# otherwise submit an empty service definition. Exit before its
+		# unconditional procd_close_service call and preserve the failure status.
+		exit 1
 	fi
 	procd_open_instance
 	procd_set_param command "$PROGRAM" serve


### PR DESCRIPTION
## Summary

Fixes the failure modes reproduced on a **GL.iNet GL-MT3000 (Beryl AX)** running OpenWrt 24.10.2 with a Quectel EC20 used for VoWiFi:

- recover the AT session when `AT+CFUN` commits but the EC20 USB serial transport disappears before returning its final response
- allow up to 45 seconds for flight-mode transitions and verify the actual CFUN state after rediscovery
- hold GL.iNet's modem auto-dial recovery lock while VoCat owns the EC20, preventing the vendor recovery process from racing VoWiFi startup
- keep SMS list/thread reads non-blocking and defer `AT+CMGL` storage scans while VoWiFi keeps cellular RF disabled
- accept Mihomo/Clash's `fdfe:dcba:9876::/48` IPv6 Fake-IP range for Bark and Telegram notification destinations, matching the existing IPv4 Fake-IP handling

## MT3000 hardware verification

Tested on the GL-MT3000 with EC20 and an overseas SIM using VoWiFi:

- VoWiFi recovered automatically after restarting VoCat and after rebooting the MT3000
- runtime reached `tunnel_ready=true`, `ims_ready=true`, and `sms_ready=true`
- SMS contacts API changed from a 40.01-second timeout to HTTP 200 in 0.011 seconds
- Bark connectivity test returned HTTP 200 with `success=true`
- Telegram connectivity test returned HTTP 200 with `success=true`

## Validation

- `go test ./cmd/vocat ./internal/device ./internal/server ./internal/vowifi/... -count=1`
- `go vet ./cmd/vocat ./internal/device ./internal/server ./internal/vowifi/...`
- `go build ./cmd/vocat`
- `sh -n scripts/install.sh scripts/vocat.openwrt.init`
- `git diff --check`

This PR contains only the six modified production source/deployment files; local regression test edits and deployment artifacts are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modem recovery when flight-mode changes fail, including confirmation that the requested mode is applied.
  * Added support for additional synthetic IPv6 notification addresses.
  * Moved modem synchronization to the background to reduce delays when loading contacts and SMS threads.
  * Improved VoWiFi behavior when modem storage scans are deferred.

* **Reliability**
  * Improved startup and shutdown cancellation handling and bounded recovery retries.
  * Prevented service startup when modem control locks cannot be safely acquired.
  * Improved cleanup and release of modem locks during service shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->