### PR TITLE
fix(openwrt): allow inbound VoWiFi SMS on dynamic TUN interfaces

### DIFF
--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -845,6 +845,7 @@ func newVoWiFiOrchestrator(
 		OnIncomingCall:        onIncomingCall,
 		OnSMS: func(ctx context.Context, message ims.ReceivedSMS) error {
 			localPhone, _ := database.PhoneNumberForICCID(ctx, message.ICCID)
+			modemIMEI := firstNonEmpty(message.ModemIMEI, deviceConfig.ModemIMEI)
 			extra, _ := json.Marshal(map[string]any{
 				"transport":                "ims",
 				"encoding":                 message.Encoding,
@@ -867,14 +868,14 @@ func newVoWiFiOrchestrator(
 				// message with a stable id so SaveSMSMessage folds every segment
 				// into one progressively merged row instead of one row per segment.
 				messageID = store.StableConcatMessageID(
-					"ims", deviceConfig.ModemIMEI, message.DeviceID, message.From,
+					"ims", modemIMEI, message.DeviceID, message.From,
 					message.Concat.Reference, message.Concat.Total,
 				)
 			}
 			_, saveErr := database.SaveSMSMessage(ctx, store.SMSMessage{
 				MessageID:  messageID,
 				DeviceID:   message.DeviceID,
-				ModemIMEI:  deviceConfig.ModemIMEI,
+				ModemIMEI:  modemIMEI,
 				ICCID:      message.ICCID,
 				IMSI:       message.IMSI,
 				LocalPhone: localPhone,
@@ -893,7 +894,7 @@ func newVoWiFiOrchestrator(
 		OnSMSStatus: func(ctx context.Context, report ims.ReceivedSMSStatus) error {
 			deliveryReport := store.SMSDeliveryReport{
 				DeviceID:          report.DeviceID,
-				ModemIMEI:         deviceConfig.ModemIMEI,
+				ModemIMEI:         firstNonEmpty(report.ModemIMEI, deviceConfig.ModemIMEI),
 				IMSI:              report.IMSI,
 				Peer:              report.To,
 				Source:            "ims",

--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -817,6 +817,21 @@ type vowifiDeviceAdapter interface {
 	vowifi.RadioController
 }
 
+// receivedIMSSMSMessageID returns a session-independent identity for an IMS SMS.
+func receivedIMSSMSMessageID(message ims.ReceivedSMS) string {
+	if message.Concat == nil || message.Concat.Total <= 1 {
+		return message.MessageID
+	}
+	// A segment of a carrier-split long SMS over IMS. Address the whole
+	// message by the configured device rather than the current IMS session's
+	// reported IMEI. A reconnect can expose another IMEI while later segments
+	// of the same message are still in flight.
+	return store.StableConcatMessageID(
+		"ims", "", message.DeviceID, message.From,
+		message.Concat.Reference, message.Concat.Total,
+	)
+}
+
 func newVoWiFiOrchestrator(
 	deviceConfig store.Device,
 	database *store.Store,
@@ -862,16 +877,7 @@ func newVoWiFiOrchestrator(
 			if message.Concat != nil && message.Concat.Total > 0 {
 				partsTotal = message.Concat.Total
 			}
-			messageID := message.MessageID
-			if message.Concat != nil && message.Concat.Total > 1 {
-				// A segment of a carrier-split long SMS over IMS. Address the whole
-				// message with a stable id so SaveSMSMessage folds every segment
-				// into one progressively merged row instead of one row per segment.
-				messageID = store.StableConcatMessageID(
-					"ims", modemIMEI, message.DeviceID, message.From,
-					message.Concat.Reference, message.Concat.Total,
-				)
-			}
+			messageID := receivedIMSSMSMessageID(message)
 			_, saveErr := database.SaveSMSMessage(ctx, store.SMSMessage{
 				MessageID:  messageID,
 				DeviceID:   message.DeviceID,

--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -817,17 +819,30 @@ type vowifiDeviceAdapter interface {
 	vowifi.RadioController
 }
 
-// receivedIMSSMSMessageID returns a session-independent identity for an IMS SMS.
+// receivedIMSSMSMessageID returns a session-independent, subscription-scoped
+// identity for an IMS SMS.
 func receivedIMSSMSMessageID(message ims.ReceivedSMS) string {
 	if message.Concat == nil || message.Concat.Total <= 1 {
 		return message.MessageID
 	}
+	subscriptionID := firstNonEmpty(
+		strings.TrimSpace(message.ICCID),
+		strings.TrimSpace(message.IMSI),
+	)
+	if subscriptionID == "" {
+		// Without a subscription identity, reusing the concat reference after an
+		// eSIM switch is indistinguishable from a later segment. Keep the IMS
+		// delivery identity instead of risking a cross-profile merge.
+		return message.MessageID
+	}
 	// A segment of a carrier-split long SMS over IMS. Address the whole
 	// message by the configured device rather than the current IMS session's
-	// reported IMEI. A reconnect can expose another IMEI while later segments
-	// of the same message are still in flight.
+	// reported IMEI, and include the subscription so a later eSIM profile cannot
+	// reuse the same sender/reference tuple and merge into the old message.
+	fingerprint := sha256.Sum256([]byte(subscriptionID))
+	deviceSubscription := message.DeviceID + ":subscription:" + hex.EncodeToString(fingerprint[:])
 	return store.StableConcatMessageID(
-		"ims", "", message.DeviceID, message.From,
+		"ims", "", deviceSubscription, message.From,
 		message.Concat.Reference, message.Concat.Total,
 	)
 }

--- a/internal/store/sms.go
+++ b/internal/store/sms.go
@@ -144,6 +144,9 @@ func saveSMSMessage(
 			// A storage rescan can happen after an eSIM profile switch. The first
 			// durable subscription identity belongs to the delivery; never replace
 			// it with whichever profile happens to be active for a later segment.
+			if canonicalIMEI := strings.TrimSpace(existing.ModemIMEI); canonicalIMEI != "" {
+				value.ModemIMEI = canonicalIMEI
+			}
 			preserveSMSSubscriptionIdentity(&value, existing)
 			if !changed {
 				if value.Read != existing.Read {
@@ -408,21 +411,26 @@ func (s *Store) ApplySMSDeliveryReport(ctx context.Context, report SMSDeliveryRe
 		return SMSMessage{}, fmt.Errorf("begin SMS delivery report: %w", err)
 	}
 	defer tx.Rollback()
+	// Prefer the report's live IMEI when it identifies a stored submission, but
+	// fall back to the stable device id because IMS session and device snapshots
+	// can legitimately expose different IMEI values during a reconnect.
 	query := smsMessageSelect + `
-		WHERE ((? <> '' AND modem_imei = ?) OR (? = '' AND device_id = ?))
+		WHERE ((? <> '' AND modem_imei = ?) OR (? <> '' AND device_id = ?))
 			AND direction IN ('outbound', 'sent')
 			AND (? = '' OR imsi = ?)
 			AND (? = '' OR peer = ?)
 			AND (? = '' OR source = ?)
-		ORDER BY created_at DESC, id DESC
+		ORDER BY CASE WHEN ? <> '' AND modem_imei = ? THEN 0 ELSE 1 END,
+			created_at DESC, id DESC
 		LIMIT 256`
 	rows, err := tx.QueryContext(
 		ctx,
 		query,
-		report.ModemIMEI, report.ModemIMEI, report.ModemIMEI, report.DeviceID,
+		report.ModemIMEI, report.ModemIMEI, report.DeviceID, report.DeviceID,
 		report.IMSI, report.IMSI,
 		report.Peer, report.Peer,
 		report.Source, report.Source,
+		report.ModemIMEI, report.ModemIMEI,
 	)
 	if err != nil {
 		return SMSMessage{}, fmt.Errorf("find SMS delivery target: %w", err)

--- a/internal/vowifi/ike/userspace_firewall.go
+++ b/internal/vowifi/ike/userspace_firewall.go
@@ -1,0 +1,99 @@
+package ike
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const openWrtFirewallCommentPrefix = "vocat-ims-"
+
+type openWrtFirewallRule struct {
+	comment   string
+	arguments []string
+}
+
+// buildOpenWrtFirewallRules permits only P-CSCF traffic addressed to the
+// negotiated inner address on the per-session TUN interface. OpenWrt fw4 uses
+// a default-drop input chain for interfaces that are not managed by netifd;
+// without these rules an IMS core can accept mobile-originated SMS while every
+// network-originated SIP MESSAGE is rejected before it reaches VoCat.
+func buildOpenWrtFirewallRules(config ChildSAConfig) []openWrtFirewallRule {
+	name := strings.TrimSpace(config.Name)
+	if name == "" {
+		return nil
+	}
+	prefix := fmt.Sprintf("%s%08x-", openWrtFirewallCommentPrefix, config.InboundSPI)
+	result := make([]openWrtFirewallRule, 0, len(config.PCSCF)*2)
+	seen := make(map[string]struct{})
+	for index, pcscf := range config.PCSCF {
+		if pcscf == nil {
+			continue
+		}
+		family := "ip"
+		local := config.InnerLocalIPv4
+		if pcscf.To4() == nil {
+			family = "ip6"
+			local = config.InnerLocalIPv6
+		}
+		if local == nil || local.IsUnspecified() {
+			continue
+		}
+		source := pcscf.String()
+		destination := local.String()
+		for _, protocol := range []string{"tcp", "udp"} {
+			key := strings.Join([]string{family, source, destination, protocol}, "|")
+			if _, duplicate := seen[key]; duplicate {
+				continue
+			}
+			seen[key] = struct{}{}
+			comment := fmt.Sprintf("%s%s-%d", prefix, protocol, index)
+			result = append(result, openWrtFirewallRule{
+				comment: comment,
+				arguments: []string{
+					"insert", "rule", "inet", "fw4", "input",
+					"iifname", name,
+					family, "saddr", source,
+					family, "daddr", destination,
+					"meta", "l4proto", protocol,
+					"counter", "accept",
+					"comment", comment,
+				},
+			})
+		}
+	}
+	return result
+}
+
+var nftHandlePattern = regexp.MustCompile(`# handle ([0-9]+)\s*$`)
+
+func nftRuleHandles(output string, comments map[string]struct{}) []string {
+	var handles []string
+	for _, line := range strings.Split(output, "\n") {
+		matchedComment := false
+		for comment := range comments {
+			if strings.Contains(line, `comment "`+comment+`"`) {
+				matchedComment = true
+				break
+			}
+		}
+		if !matchedComment {
+			continue
+		}
+		match := nftHandlePattern.FindStringSubmatch(strings.TrimSpace(line))
+		if len(match) == 2 {
+			handles = append(handles, match[1])
+		}
+	}
+	sort.Strings(handles)
+	return handles
+}
+
+func firewallRuleComments(rules []openWrtFirewallRule) map[string]struct{} {
+	result := make(map[string]struct{}, len(rules))
+	for _, rule := range rules {
+		result[rule.comment] = struct{}{}
+	}
+	return result
+}

--- a/internal/vowifi/ike/userspace_firewall.go
+++ b/internal/vowifi/ike/userspace_firewall.go
@@ -90,6 +90,44 @@ func nftRuleHandles(output string, comments map[string]struct{}) []string {
 	return handles
 }
 
+// staleOpenWrtFirewallRuleHandles returns managed rules for the same TUN
+// interface that do not belong to the current Child SA. This removes rules
+// left behind when a previous process was killed before graceful cleanup.
+func staleOpenWrtFirewallRuleHandles(
+	output string,
+	interfaceName string,
+	currentComments map[string]struct{},
+) []string {
+	interfaceName = strings.TrimSpace(interfaceName)
+	if interfaceName == "" {
+		return nil
+	}
+	interfaceMatch := `iifname "` + interfaceName + `"`
+	var handles []string
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, interfaceMatch) ||
+			!strings.Contains(line, `comment "`+openWrtFirewallCommentPrefix) {
+			continue
+		}
+		current := false
+		for comment := range currentComments {
+			if strings.Contains(line, `comment "`+comment+`"`) {
+				current = true
+				break
+			}
+		}
+		if current {
+			continue
+		}
+		match := nftHandlePattern.FindStringSubmatch(strings.TrimSpace(line))
+		if len(match) == 2 {
+			handles = append(handles, match[1])
+		}
+	}
+	sort.Strings(handles)
+	return handles
+}
+
 func firewallRuleComments(rules []openWrtFirewallRule) map[string]struct{} {
 	result := make(map[string]struct{}, len(rules))
 	for _, rule := range rules {

--- a/internal/vowifi/ike/userspace_linux.go
+++ b/internal/vowifi/ike/userspace_linux.go
@@ -271,6 +271,7 @@ func (handle *linuxUserspaceHandle) configure(ctx context.Context) error {
 	return nil
 }
 
+// configureOpenWrtFirewall prepares fw4 access for the dynamic VoWiFi tunnel.
 func (handle *linuxUserspaceHandle) configureOpenWrtFirewall(ctx context.Context) error {
 	command := strings.TrimSpace(handle.nftCommand)
 	if command == "" {
@@ -296,6 +297,7 @@ func (handle *linuxUserspaceHandle) configureOpenWrtFirewall(ctx context.Context
 	return nil
 }
 
+// ensureOpenWrtFirewall installs any managed fw4 rules missing after a reload.
 func (handle *linuxUserspaceHandle) ensureOpenWrtFirewall(ctx context.Context) error {
 	if len(handle.firewallRules) == 0 {
 		return nil
@@ -322,6 +324,7 @@ func (handle *linuxUserspaceHandle) ensureOpenWrtFirewall(ctx context.Context) e
 	return nil
 }
 
+// maintainOpenWrtFirewall restores managed rules while the tunnel remains open.
 func (handle *linuxUserspaceHandle) maintainOpenWrtFirewall() {
 	defer handle.wait.Done()
 	if len(handle.firewallRules) == 0 {
@@ -341,6 +344,7 @@ func (handle *linuxUserspaceHandle) maintainOpenWrtFirewall() {
 	}
 }
 
+// commandErrorText combines command output and its execution error for logs.
 func commandErrorText(output []byte, err error) string {
 	message := strings.TrimSpace(string(output))
 	if message == "" && err != nil {
@@ -349,6 +353,7 @@ func commandErrorText(output []byte, err error) string {
 	return message
 }
 
+// cleanupOpenWrtFirewall removes only the fw4 rules owned by this tunnel.
 func (handle *linuxUserspaceHandle) cleanupOpenWrtFirewall(ctx context.Context) error {
 	if len(handle.firewallRules) == 0 {
 		return nil

--- a/internal/vowifi/ike/userspace_linux.go
+++ b/internal/vowifi/ike/userspace_linux.go
@@ -312,6 +312,13 @@ func (handle *linuxUserspaceHandle) ensureOpenWrtFirewall(ctx context.Context) e
 		return fmt.Errorf("inspect fw4 input chain: %s", commandErrorText(output, err))
 	}
 	current := string(output)
+	comments := firewallRuleComments(handle.firewallRules)
+	for _, nftHandle := range staleOpenWrtFirewallRuleHandles(current, handle.config.Name, comments) {
+		remove := exec.CommandContext(ctx, command, "delete", "rule", "inet", "fw4", "input", "handle", nftHandle)
+		if output, err := remove.CombinedOutput(); err != nil {
+			return fmt.Errorf("remove stale fw4 rule %s: %s", nftHandle, commandErrorText(output, err))
+		}
+	}
 	for _, rule := range handle.firewallRules {
 		if strings.Contains(current, `comment "`+rule.comment+`"`) {
 			continue

--- a/internal/vowifi/ike/userspace_linux.go
+++ b/internal/vowifi/ike/userspace_linux.go
@@ -22,17 +22,20 @@ const userspaceTunnelMTU = 1380
 
 const userspaceTunnelPollInterval = 100 * time.Millisecond
 
+const openWrtFirewallEnsureInterval = 10 * time.Second
+
 type linuxUserspaceInstaller struct {
 	ipCommand string
 }
 
 type linuxUserspaceHandle struct {
-	ipCommand string
-	config    ChildSAConfig
-	tunnel    *espTunnel
-	tun       *os.File
-	tunFD     int
-	relay     NATTPacketRelay
+	ipCommand  string
+	nftCommand string
+	config     ChildSAConfig
+	tunnel     *espTunnel
+	tun        *os.File
+	tunFD      int
+	relay      NATTPacketRelay
 
 	runContext context.Context
 	cancel     context.CancelFunc
@@ -40,11 +43,12 @@ type linuxUserspaceHandle struct {
 	cancelOnce sync.Once
 	closeOnce  sync.Once
 
-	mu          sync.Mutex
-	closed      bool
-	terminalErr error
-	failures    chan error
-	cleanup     []ipCleanupCommand
+	mu            sync.Mutex
+	closed        bool
+	terminalErr   error
+	failures      chan error
+	cleanup       []ipCleanupCommand
+	firewallRules []openWrtFirewallRule
 }
 
 type ipCleanupCommand struct {
@@ -92,6 +96,7 @@ func (installer linuxUserspaceInstaller) Install(
 	runContext, cancel := context.WithCancel(context.Background())
 	handle := &linuxUserspaceHandle{
 		ipCommand:  command,
+		nftCommand: "nft",
 		config:     cloneChildSAConfig(config),
 		tunnel:     tunnel,
 		tun:        tun,
@@ -107,9 +112,10 @@ func (installer linuxUserspaceInstaller) Install(
 		_ = tun.Close()
 		return nil, err
 	}
-	handle.wait.Add(2)
+	handle.wait.Add(3)
 	go handle.copyTUNToRelay()
 	go handle.copyRelayToTUN()
+	go handle.maintainOpenWrtFirewall()
 	return handle, nil
 }
 
@@ -259,7 +265,115 @@ func (handle *linuxUserspaceHandle) configure(ctx context.Context) error {
 			return err
 		}
 	}
+	if err := handle.configureOpenWrtFirewall(ctx); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (handle *linuxUserspaceHandle) configureOpenWrtFirewall(ctx context.Context) error {
+	command := strings.TrimSpace(handle.nftCommand)
+	if command == "" {
+		command = "nft"
+	}
+	if _, err := exec.LookPath(command); err != nil {
+		return nil
+	}
+	probe := exec.CommandContext(ctx, command, "list", "chain", "inet", "fw4", "input")
+	if _, err := probe.CombinedOutput(); err != nil {
+		// fw4 is OpenWrt-specific. Other Linux hosts retain their native input
+		// policy and do not need this compatibility rule.
+		return nil
+	}
+	handle.firewallRules = buildOpenWrtFirewallRules(handle.config)
+	if len(handle.firewallRules) == 0 {
+		return nil
+	}
+	if err := handle.ensureOpenWrtFirewall(ctx); err != nil {
+		_ = handle.cleanupOpenWrtFirewall(context.Background())
+		return fmt.Errorf("ike: permit IMS input on OpenWrt TUN: %w", err)
+	}
+	return nil
+}
+
+func (handle *linuxUserspaceHandle) ensureOpenWrtFirewall(ctx context.Context) error {
+	if len(handle.firewallRules) == 0 {
+		return nil
+	}
+	command := strings.TrimSpace(handle.nftCommand)
+	if command == "" {
+		command = "nft"
+	}
+	list := exec.CommandContext(ctx, command, "-a", "list", "chain", "inet", "fw4", "input")
+	output, err := list.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("inspect fw4 input chain: %s", commandErrorText(output, err))
+	}
+	current := string(output)
+	for _, rule := range handle.firewallRules {
+		if strings.Contains(current, `comment "`+rule.comment+`"`) {
+			continue
+		}
+		install := exec.CommandContext(ctx, command, rule.arguments...)
+		if output, err := install.CombinedOutput(); err != nil {
+			return fmt.Errorf("install %s: %s", rule.comment, commandErrorText(output, err))
+		}
+	}
+	return nil
+}
+
+func (handle *linuxUserspaceHandle) maintainOpenWrtFirewall() {
+	defer handle.wait.Done()
+	if len(handle.firewallRules) == 0 {
+		return
+	}
+	ticker := time.NewTicker(openWrtFirewallEnsureInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-handle.runContext.Done():
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(handle.runContext, 5*time.Second)
+			_ = handle.ensureOpenWrtFirewall(ctx)
+			cancel()
+		}
+	}
+}
+
+func commandErrorText(output []byte, err error) string {
+	message := strings.TrimSpace(string(output))
+	if message == "" && err != nil {
+		message = err.Error()
+	}
+	return message
+}
+
+func (handle *linuxUserspaceHandle) cleanupOpenWrtFirewall(ctx context.Context) error {
+	if len(handle.firewallRules) == 0 {
+		return nil
+	}
+	command := strings.TrimSpace(handle.nftCommand)
+	if command == "" {
+		command = "nft"
+	}
+	list := exec.CommandContext(ctx, command, "-a", "list", "chain", "inet", "fw4", "input")
+	output, err := list.CombinedOutput()
+	if err != nil {
+		// A firewall reload may temporarily remove fw4; there is then nothing
+		// owned by this session left to delete.
+		return nil
+	}
+	handles := nftRuleHandles(string(output), firewallRuleComments(handle.firewallRules))
+	var errs []error
+	for _, nftHandle := range handles {
+		remove := exec.CommandContext(ctx, command, "delete", "rule", "inet", "fw4", "input", "handle", nftHandle)
+		if output, err := remove.CombinedOutput(); err != nil {
+			errs = append(errs, fmt.Errorf("remove fw4 rule %s: %s", nftHandle, commandErrorText(output, err)))
+		}
+	}
+	handle.firewallRules = nil
+	return errors.Join(errs...)
 }
 
 func (handle *linuxUserspaceHandle) configureFamily(
@@ -671,6 +785,9 @@ func (handle *linuxUserspaceHandle) cleanupNetwork(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	var errs []error
+	if err := handle.cleanupOpenWrtFirewall(ctx); err != nil {
+		errs = append(errs, err)
+	}
 	for index := len(handle.cleanup) - 1; index >= 0; index-- {
 		item := handle.cleanup[index]
 		command := exec.CommandContext(ctx, handle.ipCommand, item.arguments...)

--- a/internal/vowifi/ims/sms_runtime.go
+++ b/internal/vowifi/ims/sms_runtime.go
@@ -44,6 +44,7 @@ type ReceivedSMS struct {
 	MessageID              string
 	DeviceID               string
 	ICCID                  string
+	ModemIMEI              string
 	IMSI                   string
 	From                   string
 	Text                   string
@@ -62,6 +63,7 @@ type ReceivedSMS struct {
 type ReceivedSMSStatus struct {
 	DeviceID               string
 	ICCID                  string
+	ModemIMEI              string
 	IMSI                   string
 	To                     string
 	MessageReference       int
@@ -509,6 +511,7 @@ func (session *Session) processSMSMessage(request *sipRequest) {
 		status := ReceivedSMSStatus{
 			DeviceID:               session.request.DeviceID,
 			ICCID:                  session.request.Identity.ICCID,
+			ModemIMEI:              strings.TrimSpace(session.request.Identity.IMEI),
 			IMSI:                   session.request.Identity.IMSI,
 			To:                     message.To,
 			MessageReference:       intPtrValue(message.MessageReference),
@@ -554,6 +557,7 @@ func (session *Session) processSMSMessage(request *sipRequest) {
 			MessageID:              fmt.Sprintf("ims:%s:%d", callID, rpdu.reference),
 			DeviceID:               session.request.DeviceID,
 			ICCID:                  session.request.Identity.ICCID,
+			ModemIMEI:              strings.TrimSpace(session.request.Identity.IMEI),
 			IMSI:                   session.request.Identity.IMSI,
 			From:                   message.From,
 			Text:                   message.Text,


### PR DESCRIPTION
## Summary

Fix VoWiFi inbound SMS on GL.iNet GL-MT3000 routers running OpenWrt/fw4.

On dynamic `vocat*` TUN interfaces, fw4's default-drop input policy rejected network-originated SIP `MESSAGE` traffic even though IMS registration and mobile-originated SMS succeeded with SIP 202.

## Changes

- Detect the OpenWrt `inet fw4 input` chain and install narrowly scoped TCP/UDP accept rules for each negotiated P-CSCF, inner tunnel address, and VoCat TUN interface.
- Tag rules per IKE Child SA, restore them after firewall/OpenClash reloads, and remove them when the tunnel closes.
- Persist inbound SMS and delivery reports using the live modem IMEI, with configured IMEI as fallback, so received messages remain visible when the stored device IMEI is empty.
- Preserve the latest upstream ICCID-based SMS identity behavior.

## Validation

- GL.iNet GL-MT3000: Vodafone UK / VOXI SMS-over-IMS end-to-end loopback passed.
- `fw4` reload test: VoCat rules were automatically restored and inbound SMS continued working.
- `go test ./internal/vowifi/ike ./internal/vowifi/ims ./cmd/vocat ./internal/server -count=1`
- `go vet ./...`
- Linux amd64 cross-compilation for `internal/vowifi/ike` and `cmd/vocat`

`go test ./...` on Windows also reaches an unrelated existing `internal/qmiport` device-node file-lock failure; the same failure reproduces on clean `origin/master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic OpenWrt firewall rules for VoWiFi sessions, allowing required IMS traffic over session tunnel interfaces.
  * Firewall rules are restored automatically if removed and cleaned up when sessions end.
  * Added modem IMEI information to incoming SMS and delivery status data.

* **Bug Fixes**
  * Improved SMS identification using subscription-aware, privacy-preserving identifiers.
  * Improved handling of concatenated messages and delivery reports across reconnects and device identity changes.
  * Added detection and cleanup of stale VoWiFi firewall rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->