### PR TITLE
fix(sms): merge multipart messages across sparse storage

### DIFF
--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -683,6 +684,7 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 			snapshotString(currentEntry.Snapshot, func(snapshot *device.Snapshot) string { return snapshot.IMEI }),
 			config.ModemIMEI,
 		)
+		concatSources := modemSMSConcatSources(messages)
 		for _, message := range messages {
 			if message.Direction == device.SMSDirectionStatusReport &&
 				message.MessageReference != nil && message.StatusCode != nil {
@@ -718,7 +720,7 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 			if message.Direction == device.SMSDirectionSubmitted {
 				direction = "outbound"
 			}
-			messageID := modemSMSMessageID(message, modemIMEI, config.ID, peer)
+			messageID := modemSMSMessageID(message, modemIMEI, config.ID, peer, concatSources[modemSMSStorageKey(message)])
 			extra, _ := json.Marshal(map[string]any{
 				"modem_index":        message.Index,
 				"storage":            message.Storage,
@@ -769,7 +771,7 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 	}
 }
 
-func modemSMSMessageID(message device.SMSMessage, modemIMEI, deviceID, peer string) string {
+func modemSMSMessageID(message device.SMSMessage, modemIMEI, deviceID, peer, concatSource string) string {
 	digest := sha256.Sum256([]byte(message.RawPDU))
 	messageID := fmt.Sprintf(
 		"modem:%s:%d:%s",
@@ -783,13 +785,7 @@ func modemSMSMessageID(message device.SMSMessage, modemIMEI, deviceID, peer stri
 		// into one row without colliding with an older message that reused the
 		// same UDH reference. SM and ME can expose duplicate copies of the same
 		// slots, so the generation uses the first segment index, not storage.
-		source := "cellular_at"
-		if message.Concat.Sequence > 0 {
-			baseIndex := message.Index - (message.Concat.Sequence - 1)
-			if baseIndex >= 0 {
-				source = fmt.Sprintf("cellular_at:%d", baseIndex)
-			}
-		}
+		source := firstNonEmpty(concatSource, "cellular_at")
 		messageID = store.StableConcatMessageID(
 			source, modemIMEI, deviceID, peer,
 			message.Concat.Reference, message.Concat.Total,
@@ -838,6 +834,60 @@ func (s *Server) smsLocalPhone(
 		return strings.TrimSpace(snapshot.Phone.Number)
 	}
 	return ""
+}
+
+// modemSMSConcatSources identifies every multipart group by the storage slot of
+// its first segment. Carrier and modem storage can interleave unrelated SMS
+// between segments, so deriving that slot through index arithmetic separates a
+// single long SMS into several rows. The real first-segment slot also keeps
+// messages that reuse the same UDH reference in distinct groups.
+func modemSMSConcatSources(messages []device.SMSMessage) map[string]string {
+	firstSlots := make(map[string][]int)
+	for _, message := range messages {
+		if message.Concat == nil || message.Concat.Total <= 1 || message.Concat.Sequence != 1 {
+			continue
+		}
+		peer := firstNonEmpty(message.From, message.To)
+		if peer == "" {
+			continue
+		}
+		key := modemSMSConcatKey(message, peer)
+		firstSlots[key] = append(firstSlots[key], message.Index)
+	}
+	for key := range firstSlots {
+		sort.Ints(firstSlots[key])
+	}
+
+	result := make(map[string]string)
+	for _, message := range messages {
+		if message.Concat == nil || message.Concat.Total <= 1 {
+			continue
+		}
+		peer := firstNonEmpty(message.From, message.To)
+		if peer == "" {
+			continue
+		}
+		source := ""
+		for _, firstSlot := range firstSlots[modemSMSConcatKey(message, peer)] {
+			if firstSlot > message.Index {
+				break
+			}
+			source = fmt.Sprintf("cellular_at:%d", firstSlot)
+		}
+		if source == "" {
+			source = fmt.Sprintf("cellular_at:pending:%d", message.Index)
+		}
+		result[modemSMSStorageKey(message)] = source
+	}
+	return result
+}
+
+func modemSMSConcatKey(message device.SMSMessage, peer string) string {
+	return peer + ":" + strconv.Itoa(message.Concat.Reference) + ":" + strconv.Itoa(message.Concat.Total)
+}
+
+func modemSMSStorageKey(message device.SMSMessage) string {
+	return message.Storage + ":" + strconv.Itoa(message.Index)
 }
 
 func (s *Server) deleteSMSMessages(ctx context.Context, messages []store.SMSMessage) error {
@@ -897,13 +947,14 @@ func (s *Server) deleteModemSMS(ctx context.Context, stored store.SMSMessage) er
 	if err != nil {
 		return fmt.Errorf("list modem SMS before deletion: %w", err)
 	}
+	concatSources := modemSMSConcatSources(modemMessages)
 	locations := make(map[string]device.SMSMessage)
 	for _, message := range modemMessages {
 		peer := firstNonEmpty(message.From, message.To)
-		if peer == "" || modemSMSMessageID(message, stored.ModemIMEI, config.ID, peer) != stored.MessageID {
+		if peer == "" || modemSMSMessageID(message, stored.ModemIMEI, config.ID, peer, concatSources[modemSMSStorageKey(message)]) != stored.MessageID {
 			continue
 		}
-		locations[message.Storage+":"+strconv.Itoa(message.Index)] = message
+		locations[modemSMSStorageKey(message)] = message
 	}
 	for _, message := range locations {
 		deleteContext, cancelDelete := context.WithTimeout(ctx, 10*time.Second)

--- a/internal/server/sms_api_test.go
+++ b/internal/server/sms_api_test.go
@@ -319,8 +319,12 @@ func TestSyncModemSMSSeparatesReusedConcatReferencesWithoutCursorChurn(t *testin
 		}
 	}
 	messages := []device.SMSMessage{
-		part(20, 1, "old-a "), part(21, 2, "old-b"),
-		part(42, 1, "new-a "), part(43, 2, "new-b"),
+		// Storage slot 21 and 43 contain unrelated messages that the modem did
+		// not return in this filtered view. Multipart segments still belong to
+		// the first segment's actual slot, rather than an inferred consecutive
+		// slot number.
+		part(20, 1, "old-a "), part(25, 2, "old-b"),
+		part(42, 1, "new-a "), part(47, 2, "new-b"),
 	}
 	server := &Server{
 		store: database, logger: regionTestLogger(),


### PR DESCRIPTION
  ## 背景

  部分蜂窝模组会将长短信的多个分段存放在非连续的 SMS 存储槽位中。例如，长短信
  的第一段位于槽位 20，第二段位于槽位 25，中间槽位可能保存了其它短信或由模组过
  滤。

  原有逻辑通过“当前分段槽位 - 分段序号”推算首段槽位。该推算依赖分段连续排列。
  非连续槽位会让同一条长短信生成多个合并标识，最终保存为多条截断短信。

  Bark 通知按已保存短信逐条发送，因此会收到两条或多条截断通知。

  ## 修改内容

  - 在一次短信同步中收集所有长短信的第一分段实际槽位。
  - 以发送号码、UDH 拼接引用、总分段数和实际首段槽位构造统一的长短信标识。
  - 后续分段归入对应首段槽位的消息组。
  - 保留同一 UDH 引用在不同存储批次中的隔离能力，避免历史长短信与新长短信混
  合。
  - 更新删除短信时的分段匹配逻辑，确保删除一条长短信会删除它的全部物理分段。

  ## 验证

  新增并运行了覆盖以下场景的测试：

  - 两条长短信复用同一个 UDH 拼接引用。
  - 每条短信的分段位于非连续存储槽位。
  - 重复同步保持消息记录与通知游标稳定。
  - 同一条长短信合并为一条完整内容，Bark 只接收一次完整通知。

  ## 影响范围

  修改范围集中在蜂窝 AT 短信同步、长短信重组标识和短信删除匹配逻辑。

  普通短信、IMS 短信、短信发送与已有的连续槽位长短信流程保持原有行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multipart SMS messages stored in nonconsecutive modem slots.
  * Prevented segments from different messages from being combined incorrectly.
  * Ensured deleting a multipart SMS removes all segments belonging to the correct message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->