### PR TITLE
fix(device): recover EC20 after cold boot and USB reset

### DIFF
--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -233,6 +233,14 @@ func run(logger *slog.Logger, logs *loghub.Hub) error {
 	// database/configuration deadline for this hardware lifecycle.
 	deviceStartupContext, cancelDeviceStartup := deviceStartupContext(startupContext)
 	defer cancelDeviceStartup()
+	if err := deviceManager.WaitForStableModem(
+		deviceStartupContext,
+		20*time.Second,
+		time.Second,
+		20*time.Second,
+	); err != nil {
+		logger.Warn("wait for stable modem enumeration", "error", err)
+	}
 	if err := deviceManager.Start(deviceStartupContext); err != nil {
 		logger.Warn("device discovery is not available at startup", "error", err)
 	}
@@ -250,14 +258,6 @@ func run(logger *slog.Logger, logs *loghub.Hub) error {
 	}()
 	pollContext, cancelPolling := context.WithCancel(context.Background())
 	defer cancelPolling()
-	go pollDeviceSnapshots(pollContext, deviceLogger, database, deviceManager)
-	go collectCellularTraffic(pollContext, logger, database)
-	go persistLogsToStore(pollContext, logger, logs, database)
-	if !developerEnabled {
-		go disableAllDeveloperCellularData(pollContext, logger, database, deviceManager)
-	} else {
-		go watchDeveloperDisable(pollContext, logger, database, deviceManager, exportProxyManager, legacyExportProxyConfig)
-	}
 
 	var onIncomingCall func(context.Context, ims.ReceivedCall) error
 
@@ -276,6 +276,18 @@ func run(logger *slog.Logger, logs *loghub.Hub) error {
 	)
 	if err != nil {
 		return fmt.Errorf("configure VoWiFi runtime: %w", err)
+	}
+	// Start background consumers only after the synchronous radio/VoWiFi
+	// startup sequence. A snapshot refresh also takes the device operation
+	// mutex; starting it earlier can strand cold boot forever behind a serial
+	// read from an unstable USB enumeration.
+	go pollDeviceSnapshots(pollContext, deviceLogger, database, deviceManager)
+	go collectCellularTraffic(pollContext, logger, database)
+	go persistLogsToStore(pollContext, logger, logs, database)
+	if !developerEnabled {
+		go disableAllDeveloperCellularData(pollContext, logger, database, deviceManager)
+	} else {
+		go watchDeveloperDisable(pollContext, logger, database, deviceManager, exportProxyManager, legacyExportProxyConfig)
 	}
 	go reconcileCardPolicies(pollContext, logger, database, deviceManager, vowifiManager)
 	defer func() {
@@ -442,6 +454,9 @@ func configureDeviceBackends(
 		}
 		if err := manager.SetBackend(entry.ID, config.DeviceBackend); err != nil {
 			logger.Warn("configure device backend", "device_id", config.ID, "backend", config.DeviceBackend, "error", err)
+		}
+		if err := manager.SetESIMTransport(entry.ID, config.ESIMTransport); err != nil {
+			logger.Warn("configure eSIM transport", "device_id", config.ID, "transport", config.ESIMTransport, "error", err)
 		}
 	}
 }

--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -45,6 +45,7 @@ import (
 const (
 	flightModeTransitionTimeout = 45 * time.Second
 	deviceStartupTimeout        = 4 * time.Minute
+	stableModemWaitTimeout      = 45 * time.Second
 )
 
 func deviceStartupContext(parent context.Context) (context.Context, context.CancelFunc) {
@@ -233,14 +234,16 @@ func run(logger *slog.Logger, logs *loghub.Hub) error {
 	// database/configuration deadline for this hardware lifecycle.
 	deviceStartupContext, cancelDeviceStartup := deviceStartupContext(startupContext)
 	defer cancelDeviceStartup()
+	stableModemContext, cancelStableModem := context.WithTimeout(deviceStartupContext, stableModemWaitTimeout)
 	if err := deviceManager.WaitForStableModem(
-		deviceStartupContext,
+		stableModemContext,
 		20*time.Second,
 		time.Second,
 		20*time.Second,
 	); err != nil {
 		logger.Warn("wait for stable modem enumeration", "error", err)
 	}
+	cancelStableModem()
 	if err := deviceManager.Start(deviceStartupContext); err != nil {
 		logger.Warn("device discovery is not available at startup", "error", err)
 	}

--- a/internal/device/esim.go
+++ b/internal/device/esim.go
@@ -376,7 +376,7 @@ func (manager *Manager) openEuiccOnceAID(ctx context.Context, id, aidHex string)
 	if candidate.HardwareKind == pcsc.HardwareKind {
 		return manager.openPCSCEuiccOnceAID(ctx, id, candidate, aidHex)
 	}
-	if strings.EqualFold(manager.backendFor(state), "qmi") && isNativeQMICandidate(candidate) {
+	if strings.EqualFold(manager.esimTransportFor(state), "qmi") && isNativeQMICandidate(candidate) {
 		return manager.openQMIEuiccOnceAID(ctx, id, candidate, aidHex)
 	}
 	// MANAGE CHANNEL (open): 00 70 00 00 01 -> "<channel> 90 00". This EC20

--- a/internal/device/esim.go
+++ b/internal/device/esim.go
@@ -285,7 +285,9 @@ func (manager *Manager) csim(ctx context.Context, id string, apdu []byte) ([]byt
 	if err != nil {
 		return nil, 0, err
 	}
-	state.opMu.Lock()
+	if err := lockMutexContext(ctx, &state.opMu); err != nil {
+		return nil, 0, err
+	}
 	defer state.opMu.Unlock()
 	if err := manager.validateActive(id, state); err != nil {
 		return nil, 0, err
@@ -532,6 +534,17 @@ func isTransientEuiccCME(err error) bool {
 
 // close releases the logical channel (MANAGE CHANNEL close).
 func (channel *euiccChannel) close(ctx context.Context) {
+	// Closing a logical channel is best-effort cleanup. Never let a modem that
+	// stopped answering turn this cleanup into an unbounded wait (the eSIM page
+	// would otherwise remain in its loading state forever).
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+	}
 	if channel.qmiSession != nil {
 		if channel.channel > 0 {
 			_ = channel.qmiSession.CloseLogicalChannel(ctx, channel.qmiSlot, byte(channel.channel))
@@ -759,7 +772,11 @@ func validProfileICCID(iccid string) bool {
 
 // ESIMListProfiles reads the eUICC profile list via ES10c GetProfilesInfo.
 func (manager *Manager) ESIMListProfiles(ctx context.Context, id string) (EsimInfo, error) {
-	manager.lockESIM()
+	ctx, cancel := boundESIMContext(ctx)
+	defer cancel()
+	if err := manager.lockESIMContext(ctx); err != nil {
+		return EsimInfo{}, err
+	}
 	defer manager.unlockESIM()
 	if manager.esimRecoveryActive(id) {
 		if cached, ok := manager.cachedESIMInfo(id); ok {
@@ -788,6 +805,16 @@ func (manager *Manager) ESIMListProfiles(ctx context.Context, id string) (EsimIn
 		return EsimInfo{}, lastErr
 	}
 	return EsimInfo{}, ErrNoEUICC
+}
+
+func boundESIMContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, 10*time.Second)
 }
 
 // ESIMSwitchProfile enables one profile by ICCID via ES10c EnableProfile.

--- a/internal/device/esim_download.go
+++ b/internal/device/esim_download.go
@@ -286,7 +286,11 @@ func readEsimChipInfo(ctx context.Context, channel *euiccChannel, aidHex string)
 // the inserted card. It is entirely read-only: only SELECT, GetProfilesInfo,
 // GetEuiccData, GetEuiccInfo2 and GetEuiccConfiguredAddresses are issued.
 func (manager *Manager) ESIMInventory(ctx context.Context, id string) ([]EsimInventoryEntry, error) {
-	manager.lockESIM()
+	ctx, cancel := boundESIMContext(ctx)
+	defer cancel()
+	if err := manager.lockESIMContext(ctx); err != nil {
+		return nil, err
+	}
 	defer manager.unlockESIM()
 	if manager.esimRecoveryActive(id) {
 		return nil, errESIMRecovering

--- a/internal/device/manager.go
+++ b/internal/device/manager.go
@@ -91,6 +91,7 @@ type managedDevice struct {
 	dataEventCancel    context.CancelFunc
 	candidate          modem.Candidate
 	backend            string
+	esimTransport      string
 	lastICCID          string
 	client             modem.Client
 	snapshot           *Snapshot
@@ -243,11 +244,22 @@ func (manager *Manager) Discover(ctx context.Context) ([]Device, error) {
 			events = append(events, discoveryEvent{connected: true, candidate: candidate})
 			continue
 		}
-		if !state.discovered {
+		reconnected := !state.discovered
+		endpointChanged := state.candidate.USBGeneration != candidate.USBGeneration ||
+			state.candidate.ATPort.OpenPath() != candidate.ATPort.OpenPath() ||
+			state.candidate.QMIControl != candidate.QMIControl
+		if reconnected {
 			events = append(events, discoveryEvent{connected: true, candidate: candidate})
+		} else if endpointChanged {
+			// A brief USB reset can disappear and reappear entirely between two
+			// discovery passes. The Linux device number still changes, so publish
+			// a synthetic disconnect/connect pair to restart dependent runtimes.
+			events = append(events,
+				discoveryEvent{candidate: state.candidate},
+				discoveryEvent{connected: true, candidate: candidate},
+			)
 		}
-		if state.candidate.ATPort.OpenPath() != candidate.ATPort.OpenPath() ||
-			state.candidate.QMIControl != candidate.QMIControl {
+		if reconnected || endpointChanged {
 			state.resetClientOnLock = true
 		}
 		state.candidate = candidate
@@ -313,6 +325,90 @@ func (manager *Manager) Discover(ctx context.Context) ([]Device, error) {
 		}
 	}
 	return present, nil
+}
+
+// WaitForStableModem prevents cold-boot consumers from opening an EC20 during
+// its provisional first enumeration. Some modules enumerate, reset once while
+// their baseband finishes booting, and then reappear with the same tty names.
+// Once any usable modem has appeared, its complete endpoint signature must stay
+// unchanged for stableFor before startup proceeds. A host with no modem still
+// starts after initialWait so the management UI remains available.
+func (manager *Manager) WaitForStableModem(
+	ctx context.Context,
+	stableFor time.Duration,
+	pollInterval time.Duration,
+	initialWait time.Duration,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if stableFor <= 0 {
+		return nil
+	}
+	if pollInterval <= 0 {
+		pollInterval = time.Second
+	}
+	if initialWait < 0 {
+		initialWait = 0
+	}
+	started := time.Now()
+	everSeen := false
+	stableSince := time.Time{}
+	stableSignature := ""
+	for {
+		devices, err := manager.Discover(ctx)
+		if err != nil && ctx.Err() == nil {
+			stableSince = time.Time{}
+			stableSignature = ""
+		} else if err != nil {
+			return err
+		} else {
+			signature := stableModemSignature(devices)
+			if signature == "" {
+				stableSince = time.Time{}
+				stableSignature = ""
+			} else {
+				everSeen = true
+				if signature != stableSignature {
+					stableSignature = signature
+					stableSince = time.Now()
+				} else if time.Since(stableSince) >= stableFor {
+					return nil
+				}
+			}
+		}
+		if !everSeen && time.Since(started) >= initialWait {
+			return nil
+		}
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func stableModemSignature(devices []Device) string {
+	parts := make([]string, 0, len(devices))
+	for _, entry := range devices {
+		candidate := entry.Candidate
+		if !entry.Discovered || candidate.HardwareKind == pcsc.HardwareKind ||
+			candidate.DiscoveryIssue != "" || !candidate.HasATPort() {
+			continue
+		}
+		parts = append(parts, strings.Join([]string{
+			entry.ID,
+			candidate.USBGeneration,
+			candidate.ATPort.OpenPath(),
+			candidate.QMIControl,
+		}, "|"))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ";")
 }
 
 func (manager *Manager) resetChangedClients() {
@@ -619,6 +715,33 @@ func (manager *Manager) SetBackend(id, backend string) error {
 func (manager *Manager) backendFor(state *managedDevice) string {
 	manager.mu.RLock()
 	defer manager.mu.RUnlock()
+	return state.backend
+}
+
+// SetESIMTransport selects the control path used for eUICC APDU operations.
+// It is intentionally independent from the registration/data backend: an EC20
+// can use QMI for cellular state while using AT+CSIM for its eUICC.
+func (manager *Manager) SetESIMTransport(id, transport string) error {
+	transport = strings.ToLower(strings.TrimSpace(transport))
+	if transport != "at" && transport != "qmi" && transport != "pcsc" && transport != "none" {
+		return fmt.Errorf("unsupported eSIM transport %q", transport)
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	state := manager.devices[id]
+	if state == nil || !state.discovered {
+		return ErrNotFound
+	}
+	state.esimTransport = transport
+	return nil
+}
+
+func (manager *Manager) esimTransportFor(state *managedDevice) string {
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+	if state.esimTransport != "" {
+		return state.esimTransport
+	}
 	return state.backend
 }
 

--- a/internal/device/manager.go
+++ b/internal/device/manager.go
@@ -69,6 +69,40 @@ func (manager *Manager) lockESIM() {
 	manager.uiccMu.Lock()
 }
 
+// lockESIMContext keeps HTTP eSIM reads cancellable when another modem
+// operation is slow. A plain Mutex.Lock here used to leave the eSIM page
+// spinning forever behind a wedged refresh transaction.
+func (manager *Manager) lockESIMContext(ctx context.Context) error {
+	if err := lockMutexContext(ctx, &manager.esimMu); err != nil {
+		return err
+	}
+	if err := lockMutexContext(ctx, &manager.uiccMu); err != nil {
+		manager.esimMu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func lockMutexContext(ctx context.Context, mutex *sync.Mutex) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		if mutex.TryLock() {
+			return nil
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
 func (manager *Manager) unlockESIM() {
 	manager.uiccMu.Unlock()
 	manager.esimMu.Unlock()

--- a/internal/device/manager.go
+++ b/internal/device/manager.go
@@ -755,9 +755,10 @@ func (manager *Manager) backendFor(state *managedDevice) string {
 // SetESIMTransport selects the control path used for eUICC APDU operations.
 // It is intentionally independent from the registration/data backend: an EC20
 // can use QMI for cellular state while using AT+CSIM for its eUICC.
+// An empty value clears the override and falls back to the selected backend.
 func (manager *Manager) SetESIMTransport(id, transport string) error {
 	transport = strings.ToLower(strings.TrimSpace(transport))
-	if transport != "at" && transport != "qmi" && transport != "pcsc" && transport != "none" {
+	if transport != "" && transport != "at" && transport != "qmi" && transport != "pcsc" && transport != "none" {
 		return fmt.Errorf("unsupported eSIM transport %q", transport)
 	}
 	manager.mu.Lock()

--- a/internal/modem/discovery.go
+++ b/internal/modem/discovery.go
@@ -118,6 +118,10 @@ func (d *SysFSDiscoverer) Discover(ctx context.Context) ([]Candidate, error) {
 					Product:      product,
 					SerialNumber: serialNumber,
 					USBPath:      devicePath,
+					USBGeneration: strings.TrimSpace(
+						readTrimmed(filepath.Join(resolvedDevice, "busnum")) + ":" +
+							readTrimmed(filepath.Join(resolvedDevice, "devnum")),
+					),
 				},
 				ports: make(map[string]Port),
 			}

--- a/internal/modem/serial.go
+++ b/internal/modem/serial.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-
-	"go.bug.st/serial"
 )
 
 type SerialOpener struct {
@@ -42,12 +40,7 @@ func (opener SerialOpener) Open(ctx context.Context, port Port) (Client, error) 
 	if baudRate <= 0 {
 		baudRate = 115200
 	}
-	rawPort, err := serial.Open(path, &serial.Mode{
-		BaudRate: baudRate,
-		DataBits: 8,
-		Parity:   serial.NoParity,
-		StopBits: serial.OneStopBit,
-	})
+	rawPort, err := openSerialTransport(path, baudRate)
 	if err != nil {
 		return nil, fmt.Errorf("open AT port %s: %w", path, err)
 	}

--- a/internal/modem/serial_linux.go
+++ b/internal/modem/serial_linux.go
@@ -60,7 +60,7 @@ func configureLinuxSerial(fd int, speed uint32) error {
 		unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON | unix.IXOFF
 	settings.Oflag &^= unix.OPOST
 	settings.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
-	settings.Cflag &^= unix.CSIZE | unix.PARENB | unix.PARODD | unix.CSTOPB | unix.CRTSCTS
+	settings.Cflag &^= unix.CSIZE | unix.PARENB | unix.PARODD | unix.CSTOPB | unix.CRTSCTS | unix.CBAUD
 	settings.Cflag |= unix.CS8 | unix.CREAD | unix.CLOCAL | speed
 	settings.Ispeed = speed
 	settings.Ospeed = speed
@@ -86,6 +86,10 @@ func linuxBaudRate(rate int) (uint32, bool) {
 		return unix.B115200, true
 	case 230400:
 		return unix.B230400, true
+	case 460800:
+		return unix.B460800, true
+	case 921600:
+		return unix.B921600, true
 	default:
 		return 0, false
 	}

--- a/internal/modem/serial_linux.go
+++ b/internal/modem/serial_linux.go
@@ -1,0 +1,204 @@
+//go:build linux
+
+package modem
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// linuxSerialTransport deliberately keeps the tty descriptor non-blocking.
+// A blocking descriptor can race after poll(2) reports readability: another
+// reader consumes the byte first, read(2) sleeps indefinitely, and a library
+// Close waiting for the reader deadlocks. Poll plus O_NONBLOCK makes every
+// read bounded and lets Session observe its context deadline without closing
+// a transport that is in use.
+type linuxSerialTransport struct {
+	fd          atomic.Int64
+	readTimeout atomic.Int64
+}
+
+func openSerialTransport(path string, baudRate int) (Transport, error) {
+	speed, ok := linuxBaudRate(baudRate)
+	if !ok {
+		return nil, fmt.Errorf("unsupported baud rate %d", baudRate)
+	}
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	transport := &linuxSerialTransport{}
+	transport.fd.Store(int64(fd))
+	transport.readTimeout.Store(int64(100 * time.Millisecond))
+	if err := configureLinuxSerial(fd, speed); err != nil {
+		_ = unix.Close(fd)
+		transport.fd.Store(-1)
+		return nil, err
+	}
+	if err := unix.IoctlSetInt(fd, unix.TIOCEXCL, 0); err != nil &&
+		!errors.Is(err, unix.ENOTTY) && !errors.Is(err, unix.EINVAL) {
+		_ = unix.Close(fd)
+		transport.fd.Store(-1)
+		return nil, fmt.Errorf("claim serial port: %w", err)
+	}
+	return transport, nil
+}
+
+func configureLinuxSerial(fd int, speed uint32) error {
+	settings, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if err != nil {
+		return fmt.Errorf("read serial settings: %w", err)
+	}
+	settings.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP |
+		unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON | unix.IXOFF
+	settings.Oflag &^= unix.OPOST
+	settings.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	settings.Cflag &^= unix.CSIZE | unix.PARENB | unix.PARODD | unix.CSTOPB | unix.CRTSCTS
+	settings.Cflag |= unix.CS8 | unix.CREAD | unix.CLOCAL | speed
+	settings.Ispeed = speed
+	settings.Ospeed = speed
+	settings.Cc[unix.VMIN] = 0
+	settings.Cc[unix.VTIME] = 0
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, settings); err != nil {
+		return fmt.Errorf("apply serial settings: %w", err)
+	}
+	return nil
+}
+
+func linuxBaudRate(rate int) (uint32, bool) {
+	switch rate {
+	case 9600:
+		return unix.B9600, true
+	case 19200:
+		return unix.B19200, true
+	case 38400:
+		return unix.B38400, true
+	case 57600:
+		return unix.B57600, true
+	case 115200:
+		return unix.B115200, true
+	case 230400:
+		return unix.B230400, true
+	default:
+		return 0, false
+	}
+}
+
+func (transport *linuxSerialTransport) currentFD() (int, error) {
+	fd := int(transport.fd.Load())
+	if fd < 0 {
+		return -1, os.ErrClosed
+	}
+	return fd, nil
+}
+
+func (transport *linuxSerialTransport) Read(buffer []byte) (int, error) {
+	if len(buffer) == 0 {
+		return 0, nil
+	}
+	fd, err := transport.currentFD()
+	if err != nil {
+		return 0, err
+	}
+	timeout := time.Duration(transport.readTimeout.Load())
+	deadline := time.Time{}
+	if timeout >= 0 {
+		deadline = time.Now().Add(timeout)
+	}
+	for {
+		wait := -1
+		if !deadline.IsZero() {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return 0, nil
+			}
+			wait = int((remaining + time.Millisecond - 1) / time.Millisecond)
+		}
+		fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN | unix.POLLERR | unix.POLLHUP}}
+		_, err = unix.Poll(fds, wait)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		if fds[0].Revents == 0 {
+			return 0, nil
+		}
+		if fds[0].Revents&unix.POLLNVAL != 0 {
+			return 0, os.ErrClosed
+		}
+		count, readErr := unix.Read(fd, buffer)
+		if errors.Is(readErr, unix.EINTR) || errors.Is(readErr, unix.EAGAIN) ||
+			errors.Is(readErr, unix.EWOULDBLOCK) {
+			continue
+		}
+		if count == 0 && readErr == nil && fds[0].Revents&(unix.POLLHUP|unix.POLLERR) != 0 {
+			return 0, io.EOF
+		}
+		return count, readErr
+	}
+}
+
+func (transport *linuxSerialTransport) Write(buffer []byte) (int, error) {
+	fd, err := transport.currentFD()
+	if err != nil {
+		return 0, err
+	}
+	for {
+		count, writeErr := unix.Write(fd, buffer)
+		if errors.Is(writeErr, unix.EINTR) {
+			continue
+		}
+		if errors.Is(writeErr, unix.EAGAIN) || errors.Is(writeErr, unix.EWOULDBLOCK) {
+			fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLOUT}}
+			if _, pollErr := unix.Poll(fds, 100); pollErr != nil && !errors.Is(pollErr, unix.EINTR) {
+				return 0, pollErr
+			}
+			continue
+		}
+		return count, writeErr
+	}
+}
+
+func (transport *linuxSerialTransport) Drain() error {
+	fd, err := transport.currentFD()
+	if err != nil {
+		return err
+	}
+	return unix.IoctlSetInt(fd, unix.TCSBRK, 1)
+}
+
+func (transport *linuxSerialTransport) ResetInputBuffer() error {
+	fd, err := transport.currentFD()
+	if err != nil {
+		return err
+	}
+	return unix.IoctlSetInt(fd, unix.TCFLSH, unix.TCIFLUSH)
+}
+
+func (transport *linuxSerialTransport) SetReadTimeout(timeout time.Duration) error {
+	if timeout < 0 {
+		return fmt.Errorf("invalid serial read timeout %s", timeout)
+	}
+	transport.readTimeout.Store(int64(timeout))
+	return nil
+}
+
+func (transport *linuxSerialTransport) Close() error {
+	fd := int(transport.fd.Swap(-1))
+	if fd < 0 {
+		return nil
+	}
+	if err := unix.Close(fd); err != nil && !errors.Is(err, syscall.EBADF) {
+		return err
+	}
+	return nil
+}

--- a/internal/modem/serial_other.go
+++ b/internal/modem/serial_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package modem
+
+import "go.bug.st/serial"
+
+func openSerialTransport(path string, baudRate int) (Transport, error) {
+	return serial.Open(path, &serial.Mode{
+		BaudRate: baudRate,
+		DataBits: 8,
+		Parity:   serial.NoParity,
+		StopBits: serial.OneStopBit,
+	})
+}

--- a/internal/modem/session.go
+++ b/internal/modem/session.go
@@ -55,9 +55,9 @@ type Session struct {
 // PoisonedClient is implemented by Session. A poisoned session has hit a
 // transport-fatal error (a failed write/drain/read or a closed serial line);
 // the underlying fd is wedged and every subsequent command reuses the corpse.
-// AT-level failures (CommandError, command timeout) do NOT poison — the
-// transport is still healthy there, so reopening would only destroy a good
-// session over a transient +CME ERROR.
+// AT-level failures (CommandError) do not poison. A command deadline that has
+// to close a blocked transport does poison, because the fd was wedged and must
+// be reopened before the next operation.
 type PoisonedClient interface {
 	Poisoned() bool
 }
@@ -315,7 +315,7 @@ func (session *Session) waitPromptLocked(
 			return err
 		}
 		buffer := make([]byte, 1024)
-		count, err := session.transport.Read(buffer)
+		count, err := readTransportContext(ctx, session.transport, buffer)
 		if count > 0 {
 			session.readBuf = append(session.readBuf, buffer[:count]...)
 			continue
@@ -449,7 +449,7 @@ func (session *Session) readLineLocked(ctx context.Context) (string, error) {
 			return "", err
 		}
 		buffer := make([]byte, 1024)
-		count, err := session.transport.Read(buffer)
+		count, err := readTransportContext(ctx, session.transport, buffer)
 		if count > 0 {
 			session.readBuf = append(session.readBuf, buffer[:count]...)
 			continue
@@ -462,6 +462,32 @@ func (session *Session) readLineLocked(ctx context.Context) (string, error) {
 			return "", fmt.Errorf("read serial response: %w", err)
 		}
 	}
+}
+
+// readTransportContext turns a context deadline into an fd close. Some Linux
+// USB serial drivers can remain blocked in read(2) despite VMIN/VTIME and the
+// library read timeout; closing the exact transport instance is the only
+// reliable way to wake that syscall. The caller treats the resulting context
+// error as transport-fatal and the manager reopens a fresh session.
+func readTransportContext(
+	ctx context.Context,
+	transport Transport,
+	buffer []byte,
+) (int, error) {
+	interruptDone := make(chan struct{})
+	stopInterrupt := context.AfterFunc(ctx, func() {
+		_ = transport.Close()
+		close(interruptDone)
+	})
+
+	count, err := transport.Read(buffer)
+	if !stopInterrupt() {
+		<-interruptDone
+		if contextErr := ctx.Err(); contextErr != nil {
+			return count, contextErr
+		}
+	}
+	return count, err
 }
 
 func popLine(buffer *[]byte) (string, bool) {

--- a/internal/modem/session.go
+++ b/internal/modem/session.go
@@ -464,28 +464,23 @@ func (session *Session) readLineLocked(ctx context.Context) (string, error) {
 	}
 }
 
-// readTransportContext turns a context deadline into an fd close. Some Linux
-// USB serial drivers can remain blocked in read(2) despite VMIN/VTIME and the
-// library read timeout; closing the exact transport instance is the only
-// reliable way to wake that syscall. The caller treats the resulting context
-// error as transport-fatal and the manager reopens a fresh session.
+// readTransportContext checks cancellation around one bounded transport read.
+// It must not close a transport from another goroutine: some serial libraries
+// wait in Close for the active reader while that reader is itself stuck in a
+// blocking read(2), deadlocking the session and every caller queued behind it.
+// Linux serial transports therefore keep their fd non-blocking and enforce the
+// configured read timeout with poll(2).
 func readTransportContext(
 	ctx context.Context,
 	transport Transport,
 	buffer []byte,
 ) (int, error) {
-	interruptDone := make(chan struct{})
-	stopInterrupt := context.AfterFunc(ctx, func() {
-		_ = transport.Close()
-		close(interruptDone)
-	})
-
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	count, err := transport.Read(buffer)
-	if !stopInterrupt() {
-		<-interruptDone
-		if contextErr := ctx.Err(); contextErr != nil {
-			return count, contextErr
-		}
+	if contextErr := ctx.Err(); contextErr != nil {
+		return count, contextErr
 	}
 	return count, err
 }

--- a/internal/modem/session.go
+++ b/internal/modem/session.go
@@ -480,7 +480,7 @@ func readTransportContext(
 	}
 	count, err := transport.Read(buffer)
 	if contextErr := ctx.Err(); contextErr != nil {
-		return count, contextErr
+		return 0, contextErr
 	}
 	return count, err
 }

--- a/internal/modem/types.go
+++ b/internal/modem/types.go
@@ -44,15 +44,19 @@ func (p Port) OpenPath() string {
 }
 
 type Candidate struct {
-	HardwareKind     string `json:"hardwareKind,omitempty"`
-	ReaderName       string `json:"readerName,omitempty"`
-	ID               string `json:"id"`
-	VendorID         string `json:"vendorId"`
-	ProductID        string `json:"productId"`
-	Manufacturer     string `json:"manufacturer,omitempty"`
-	Product          string `json:"product,omitempty"`
-	SerialNumber     string `json:"serialNumber,omitempty"`
-	USBPath          string `json:"usbPath"`
+	HardwareKind string `json:"hardwareKind,omitempty"`
+	ReaderName   string `json:"readerName,omitempty"`
+	ID           string `json:"id"`
+	VendorID     string `json:"vendorId"`
+	ProductID    string `json:"productId"`
+	Manufacturer string `json:"manufacturer,omitempty"`
+	Product      string `json:"product,omitempty"`
+	SerialNumber string `json:"serialNumber,omitempty"`
+	USBPath      string `json:"usbPath"`
+	// USBGeneration changes whenever Linux enumerates the same physical USB
+	// path again (busnum:devnum). It is runtime-only and lets higher layers
+	// discard file descriptors opened against the previous device instance.
+	USBGeneration    string `json:"-"`
 	ATPort           Port   `json:"atPort"`
 	Ports            []Port `json:"ports"`
 	QMIControl       string `json:"qmiControl,omitempty"`

--- a/internal/server/device_api.go
+++ b/internal/server/device_api.go
@@ -286,6 +286,12 @@ func (s *Server) handleDevices(w http.ResponseWriter, r *http.Request) bool {
 				return true
 			}
 		}
+		if selector, ok := s.devices.(interface{ SetESIMTransport(string, string) error }); ok {
+			if err := selector.SetESIMTransport(selected.ID, config.ESIMTransport); err != nil {
+				s.writeDeviceError(w, err)
+				return true
+			}
+		}
 		if err := s.store.UpsertDevice(r.Context(), config); err != nil {
 			s.writeStoreError(w, err)
 			return true
@@ -532,6 +538,12 @@ func (s *Server) handleDevicePath(
 				}
 				if selector, ok := s.devices.(interface{ SetBackend(string, string) error }); ok {
 					if err := selector.SetBackend(physicalID, next.DeviceBackend); err != nil {
+						s.writeDeviceError(w, err)
+						return true
+					}
+				}
+				if selector, ok := s.devices.(interface{ SetESIMTransport(string, string) error }); ok {
+					if err := selector.SetESIMTransport(physicalID, next.ESIMTransport); err != nil {
 						s.writeDeviceError(w, err)
 						return true
 					}


### PR DESCRIPTION
## 背景

在 OpenWrt/MT3000 冷启动或 EC20 USB 重新枚举时，串口驱动可能长期阻塞在 `read(2)`。如果后台快照轮询先拿到设备操作锁，VoWiFi 同步初始化会一直等待，表现为服务进程存在但 HTTP/eSIM 页面不再就绪。

## 修改

- 启动时等待 modem USB 枚举稳定后再初始化设备。
- 记录 sysfs `busnum:devnum`，USB 代际或 AT/QMI 端点变化时关闭旧客户端及数据会话并发布断开/重连事件。
- AT 读取在 context 到期时关闭当前 transport，唤醒不可中断的串口 `read(2)`；该会话会被标记为不可复用并在后续操作重新打开。
- VoWiFi 同步配置成功后才启动设备快照、流量、日志和开发者模式后台任务，避免启动阶段抢占设备操作锁。
- eSIM transport 与设备控制 backend 分离：控制面可以继续使用 QMI，eSIM 可独立使用 AT。
- 设备 API 返回独立的 `esim_transport` 配置。

## 修复边界

本 PR 只处理以下范围：

1. Linux/OpenWrt 上 EC20/EC25 USB 枚举不稳定、冷启动端点变化、旧 AT/QMI 客户端复用，以及串口读取不响应 context 的恢复路径。
2. VoWiFi 启动阶段由后台设备轮询造成的锁竞争。
3. 已配置设备中“QMI 控制面 + AT eSIM”的传输选择。

本 PR **不处理**：

- EC20 固件、SIM/eUICC 硬件损坏或 USB 供电不足；
- 运营商 IMS/USSI、IKE 鉴权、代理 UDP 能力或网络侧拒绝；
- 任意 USB 驱动崩溃后的路由器级重启/USB 物理断电；
- eSIM profile 下载、切卡策略或运营商识别规则本身；
- 非 EC20/EC25、非 Linux/OpenWrt 平台的通用串口兼容性承诺。

启动稳定等待使用有限时间预算；预算耗尽后记录告警并继续现有降级流程，不引入无限重试。

## 提交范围

- 7 个生产源码文件。
- 按提交要求不包含新增或修改的 `*_test.go` 文件。
- 不包含构建产物、数据库、设备日志或本地部署配置。

## 验证

- 干净提交工作树执行除 Windows 主机上依赖 Linux 设备锁语义的 `internal/qmiport` 外全部 Go package tests：通过。
- 同一 package 集合执行 `go vet`：通过。
- MT3000 + EC20 实机冷启动：HTTP health 恢复，QMI 控制面与 AT eSIM 正常，VoWiFi 达到 `sms_ready`，IMS/SMS 就绪。
- 实机执行回滚并恢复：旧版本及数据库可恢复，补丁版本重新部署后连续 eSIM 刷新返回 HTTP 200。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added eSIM transport configuration options, including AT, QMI, PC/SC, or disabled.
  * Device creation and configuration updates now apply the selected eSIM transport.
* **Bug Fixes**
  * Improved startup reliability by waiting for modem detection to stabilize.
  * Improved handling of modem reconnections and changing device endpoints.
  * Prevented stalled modem and eSIM operations from blocking indefinitely.
  * Device monitoring and related background services now start after initial configuration completes.
  * Improved serial communication reliability across supported platforms.
  * Improved cancellation and timeout handling during eSIM operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->