### PR TITLE
fix(sms): accept slot zero and skip empty notifications

### DIFF
--- a/internal/device/sms.go
+++ b/internal/device/sms.go
@@ -406,7 +406,7 @@ func parseCMGLHeader(line string) smsRecordHeader {
 	}
 	var ok bool
 	header.index, ok = parseDecimal(values[0])
-	if !ok || header.index <= 0 {
+	if !ok || header.index < 0 {
 		header.err = errors.New("invalid CMGL message index")
 	}
 	header.status = parseSMSStorageStatus(values[1])

--- a/internal/server/sms_notifications.go
+++ b/internal/server/sms_notifications.go
@@ -104,7 +104,7 @@ func (s *Server) runSMSNotificationChannel(ctx context.Context, channel string) 
 				}
 			} else {
 				for _, message := range messages {
-					if !store.ConcatSMSReadyToNotify(message.MessageID, message.Extra) {
+					if !smsMessageReadyToNotify(message) {
 						cursor = message.ID
 						continue
 					}
@@ -125,6 +125,11 @@ func (s *Server) runSMSNotificationChannel(ctx context.Context, channel string) 
 			return
 		}
 	}
+}
+
+func smsMessageReadyToNotify(message store.SMSMessage) bool {
+	return strings.TrimSpace(message.Body) != "" &&
+		store.ConcatSMSReadyToNotify(message.MessageID, message.Extra)
 }
 
 func (s *Server) smsNotificationConfig(ctx context.Context, channel string) (map[string]any, bool, error) {

--- a/internal/server/telegram_bot.go
+++ b/internal/server/telegram_bot.go
@@ -2288,12 +2288,10 @@ func (bot *telegramBot) notifyInboundSMS(ctx context.Context) {
 				bot.warn("list Telegram SMS notifications", listErr)
 			} else {
 				for _, message := range messages {
-					if !store.ConcatSMSReadyToNotify(message.MessageID, message.Extra) {
-						// A carrier-split long SMS still waiting for segments. Hold
-						// the notification but advance the cursor so the partial row
-						// is not reconsidered every poll; when the final segment
-						// merges, the row re-enters with a fresh id and is pushed
-						// here as one complete message.
+					if !smsMessageReadyToNotify(message) {
+						// Empty decoded messages and multipart messages still waiting
+						// for segments are not user-notifiable. Advance the cursor;
+						// a completed multipart row re-enters with a fresh id.
 						cursor = message.ID
 						continue
 					}


### PR DESCRIPTION
## Summary

- accept zero-based EC20 `+CMGL` storage indexes so slot 0 messages are decoded instead of discarded
- suppress notifications for SMS records whose decoded body is empty
- apply the same notification eligibility rule to Telegram and notification-only channels

## Root cause

Some EC20 firmware exposes valid SMS storage slots starting at index 0. VoCat treated indexes less than or equal to zero as invalid, so a multipart SMS with its first segment in slot 0 was persisted using only later segments.

After slot 0 became readable, historical truncated PDUs could also be synchronized. These records have an empty body and a decode error, but the notification dispatchers previously only filtered incomplete concatenated messages, resulting in empty Bark and Telegram notifications.

## Scope

This change only:

- permits `+CMGL` index 0
- skips user notifications when the decoded SMS body is empty
- preserves incomplete or undecodable records in SMS storage for diagnostics

It does not alter PDU decoding, modem storage deletion, SMS history retention, or multipart merge rules.

## Verification

- `go test ./internal/device ./internal/server ./cmd/vocat -count=1`
- `go vet ./internal/device ./internal/server ./cmd/vocat`
- `git diff --check`

Validated on an MT3000 with a Quectel EC20:
- multipart segment 1 was recovered from slot 0 and merged with segment 2
- empty truncated records no longer enter notification channels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbound SMS notification handling by skipping messages with empty or whitespace-only content.
  * Improved processing of multipart SMS messages, ensuring incomplete messages are skipped and completed messages can be notified correctly.
  * Corrected handling of SMS messages stored at index zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->