### PR TITLE
fix(device): recover EC20 from prolonged network search

### DIFF
--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -46,7 +46,272 @@ const (
 	flightModeTransitionTimeout = 45 * time.Second
 	deviceStartupTimeout        = 4 * time.Minute
 	stableModemWaitTimeout      = 45 * time.Second
+	ec20RegistrationGrace       = 2 * time.Minute
+	ec20RegistrationEscalation  = 3 * time.Minute
 )
+
+type registrationRecoveryAction uint8
+
+const (
+	registrationRecoveryNone registrationRecoveryAction = iota
+	registrationRecoveryReregister
+	registrationRecoveryReboot
+)
+
+type registrationRecoveryEpisode struct {
+	iccid       string
+	searchingAt time.Time
+	lastAttempt time.Time
+	attempts    int
+	pending     registrationRecoveryAction
+}
+
+type registrationRecoveryTracker struct {
+	mu         sync.Mutex
+	grace      time.Duration
+	escalation time.Duration
+	episodes   map[string]registrationRecoveryEpisode
+}
+
+type registrationRecoveryDevices interface {
+	Refresh(context.Context, string) (device.Snapshot, error)
+	PrepareRegistration(context.Context, string, string, string) error
+	ReRegisterOperator(context.Context, string) (device.OperatorSelection, error)
+	Reboot(context.Context, string) error
+}
+
+type registrationRecoveryPolicies interface {
+	CardPolicy(context.Context, string) (store.CardPolicy, error)
+}
+
+func explicitRegistrationRecoveryFlightMode(snapshot device.Snapshot) bool {
+	return snapshot.ModeKnown && snapshot.OperatingMode == 4
+}
+
+func newRegistrationRecoveryTracker(grace, escalation time.Duration) *registrationRecoveryTracker {
+	return &registrationRecoveryTracker{
+		grace: grace, escalation: escalation,
+		episodes: make(map[string]registrationRecoveryEpisode),
+	}
+}
+
+func (tracker *registrationRecoveryTracker) observe(
+	deviceID string,
+	snapshot *device.Snapshot,
+	now time.Time,
+) registrationRecoveryAction {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if snapshot == nil {
+		return registrationRecoveryNone
+	}
+	if explicitRegistrationRecoveryFlightMode(*snapshot) ||
+		snapshot.RegistrationStatus == 1 || snapshot.RegistrationStatus == 5 {
+		delete(tracker.episodes, deviceID)
+		return registrationRecoveryNone
+	}
+	iccid := strings.TrimSpace(snapshot.ICCID)
+	episode, found := tracker.episodes[deviceID]
+	if found && iccid != "" && episode.iccid != iccid {
+		delete(tracker.episodes, deviceID)
+		found = false
+	}
+	// A CFUN reboot temporarily clears the snapshot while the SIM and ICCID are
+	// still initializing. Preserve an existing episode through that interval so
+	// the one-reboot limit cannot be re-armed by the reboot itself.
+	if !snapshot.SIMReady ||
+		!strings.HasPrefix(strings.ToUpper(strings.TrimSpace(snapshot.Model)), "EC20") ||
+		iccid == "" ||
+		(snapshot.RegistrationStatus != 0 && snapshot.RegistrationStatus != 2) {
+		return registrationRecoveryNone
+	}
+	if !found {
+		tracker.episodes[deviceID] = registrationRecoveryEpisode{iccid: iccid, searchingAt: now}
+		return registrationRecoveryNone
+	}
+	if episode.pending != registrationRecoveryNone {
+		return registrationRecoveryNone
+	}
+	if episode.attempts == 0 && now.Sub(episode.searchingAt) >= tracker.grace {
+		episode.pending = registrationRecoveryReregister
+		tracker.episodes[deviceID] = episode
+		return registrationRecoveryReregister
+	}
+	if episode.attempts == 1 && now.Sub(episode.lastAttempt) >= tracker.escalation {
+		episode.pending = registrationRecoveryReboot
+		tracker.episodes[deviceID] = episode
+		return registrationRecoveryReboot
+	}
+	return registrationRecoveryNone
+}
+
+func (tracker *registrationRecoveryTracker) complete(
+	deviceID string,
+	expectedICCID string,
+	action registrationRecoveryAction,
+	issued bool,
+	now time.Time,
+) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	episode, found := tracker.episodes[deviceID]
+	if !found || episode.iccid != strings.TrimSpace(expectedICCID) || episode.pending != action {
+		return
+	}
+	episode.pending = registrationRecoveryNone
+	if issued {
+		episode.attempts++
+		episode.lastAttempt = now
+	}
+	tracker.episodes[deviceID] = episode
+}
+
+func registrationRecoveryEligible(snapshot device.Snapshot, expectedICCID string) bool {
+	iccid := strings.TrimSpace(snapshot.ICCID)
+	return snapshot.SIMReady && !snapshot.FlightMode && !snapshot.RadioOff &&
+		strings.HasPrefix(strings.ToUpper(strings.TrimSpace(snapshot.Model)), "EC20") &&
+		iccid != "" && iccid == strings.TrimSpace(expectedICCID) &&
+		(snapshot.RegistrationStatus == 0 || snapshot.RegistrationStatus == 2)
+}
+
+func registrationRecoverySuperseded(snapshot device.Snapshot, expectedICCID string) bool {
+	iccid := strings.TrimSpace(snapshot.ICCID)
+	model := strings.ToUpper(strings.TrimSpace(snapshot.Model))
+	if explicitRegistrationRecoveryFlightMode(snapshot) || (model != "" && !strings.HasPrefix(model, "EC20")) {
+		return true
+	}
+	if iccid != "" && iccid != strings.TrimSpace(expectedICCID) {
+		return true
+	}
+	if snapshot.RegistrationStatus == 1 || snapshot.RegistrationStatus == 5 {
+		return true
+	}
+	return snapshot.SIMReady && iccid != "" &&
+		snapshot.RegistrationStatus != 0 && snapshot.RegistrationStatus != 2
+}
+
+func revalidateRegistrationRecovery(
+	ctx context.Context,
+	devices registrationRecoveryDevices,
+	deviceID string,
+	expectedICCID string,
+) (device.Snapshot, bool, error) {
+	snapshot, err := devices.Refresh(ctx, deviceID)
+	if err != nil {
+		return device.Snapshot{}, false, err
+	}
+	return snapshot, registrationRecoveryEligible(snapshot, expectedICCID), nil
+}
+
+func runRegistrationRecovery(
+	ctx context.Context,
+	logger *slog.Logger,
+	policies registrationRecoveryPolicies,
+	devices registrationRecoveryDevices,
+	deviceID string,
+	expectedICCID string,
+	action registrationRecoveryAction,
+) bool {
+	issued := false
+	current, eligible, err := revalidateRegistrationRecovery(ctx, devices, deviceID, expectedICCID)
+	if err != nil || !eligible {
+		return false
+	}
+	if action == registrationRecoveryReboot {
+		// Revalidate immediately before the destructive operation so a recovered
+		// modem, SIM swap, or flight-mode transition cannot inherit a stale action.
+		if _, eligible, err = revalidateRegistrationRecovery(ctx, devices, deviceID, expectedICCID); err != nil || !eligible {
+			return false
+		}
+		if err = devices.Reboot(ctx, deviceID); err != nil {
+			logger.Warn("EC20 registration recovery reboot failed", "device_id", deviceID, "error", err)
+			return true
+		}
+		// CFUN reboot resets EC20 CID 1 on affected firmware. Wait for the AT
+		// transport to return, then reload the current card policy and revalidate
+		// before every modem operation.
+		for attempt := 0; attempt < 12 && ctx.Err() == nil; attempt++ {
+			timer := time.NewTimer(5 * time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return true
+			case <-timer.C:
+			}
+			current, eligible, err = revalidateRegistrationRecovery(ctx, devices, deviceID, expectedICCID)
+			if err != nil {
+				continue
+			}
+			if !eligible {
+				if registrationRecoverySuperseded(current, expectedICCID) {
+					return true
+				}
+				continue
+			}
+			policy, policyErr := policies.CardPolicy(ctx, strings.TrimSpace(current.ICCID))
+			if policyErr == nil && strings.TrimSpace(policy.APN) != "" {
+				current, eligible, err = revalidateRegistrationRecovery(ctx, devices, deviceID, expectedICCID)
+				if err != nil {
+					continue
+				}
+				if !eligible {
+					if registrationRecoverySuperseded(current, expectedICCID) {
+						return true
+					}
+					continue
+				}
+				ipVersion := policy.IPVersion
+				if ipVersion == "" {
+					ipVersion = "IPV4V6"
+				}
+				if err = devices.PrepareRegistration(ctx, deviceID, policy.APN, ipVersion); err != nil {
+					continue
+				}
+			}
+			current, eligible, err = revalidateRegistrationRecovery(ctx, devices, deviceID, expectedICCID)
+			if err != nil {
+				continue
+			}
+			if !eligible {
+				if registrationRecoverySuperseded(current, expectedICCID) {
+					return true
+				}
+				continue
+			}
+			if _, err = devices.ReRegisterOperator(ctx, deviceID); err == nil {
+				logger.Info("EC20 registration recovery rebooted modem", "device_id", deviceID)
+				return true
+			}
+		}
+		logger.Warn("EC20 registration recovery could not resume after reboot", "device_id", deviceID)
+		return true
+	}
+
+	policy, policyErr := policies.CardPolicy(ctx, strings.TrimSpace(current.ICCID))
+	if policyErr == nil && strings.TrimSpace(policy.APN) != "" {
+		if _, eligible, err = revalidateRegistrationRecovery(ctx, devices, deviceID, expectedICCID); err != nil || !eligible {
+			return issued
+		}
+		ipVersion := policy.IPVersion
+		if ipVersion == "" {
+			ipVersion = "IPV4V6"
+		}
+		issued = true
+		if err = devices.PrepareRegistration(ctx, deviceID, policy.APN, ipVersion); err != nil {
+			logger.Warn("EC20 registration recovery could not prepare PDP context", "device_id", deviceID, "error", err)
+		}
+	}
+	if _, eligible, err = revalidateRegistrationRecovery(ctx, devices, deviceID, expectedICCID); err != nil || !eligible {
+		return issued
+	}
+	issued = true
+	if _, err = devices.ReRegisterOperator(ctx, deviceID); err != nil {
+		logger.Warn("EC20 registration recovery failed", "device_id", deviceID, "error", err)
+		return true
+	}
+	logger.Info("EC20 registration recovery requested", "device_id", deviceID)
+	return issued
+}
 
 func deviceStartupContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(parent), deviceStartupTimeout)
@@ -1128,6 +1393,27 @@ func pollDeviceSnapshots(
 	database *store.Store,
 	manager *device.Manager,
 ) {
+	recoveryTracker := newRegistrationRecoveryTracker(ec20RegistrationGrace, ec20RegistrationEscalation)
+	recoverRegistration := func(entry device.Device, snapshot device.Snapshot, action registrationRecoveryAction) {
+		if action == registrationRecoveryNone {
+			return
+		}
+		go func() {
+			recoveryContext, cancel := context.WithTimeout(ctx, 3*time.Minute)
+			defer cancel()
+			expectedICCID := strings.TrimSpace(snapshot.ICCID)
+			issued := runRegistrationRecovery(
+				recoveryContext,
+				logger,
+				database,
+				manager,
+				entry.ID,
+				expectedICCID,
+				action,
+			)
+			recoveryTracker.complete(entry.ID, expectedICCID, action, issued, time.Now())
+		}()
+	}
 	refresh := func() {
 		discoveryContext, cancelDiscovery := context.WithTimeout(ctx, 10*time.Second)
 		_, err := manager.Discover(discoveryContext)
@@ -1168,6 +1454,7 @@ func pollDeviceSnapshots(
 				if refreshErr == nil && ctx.Err() == nil {
 					enforceCardRegion(ctx, logger, database, manager, entry.ID, &snapshot)
 					enforceDefaultSafeCardPolicy(ctx, logger, database, manager, entry.ID, &snapshot)
+					recoverRegistration(entry, snapshot, recoveryTracker.observe(entry.ID, &snapshot, time.Now()))
 				}
 			}()
 		}

--- a/internal/device/data.go
+++ b/internal/device/data.go
@@ -368,6 +368,46 @@ func normalizeIPVersion(value string) string {
 	}
 }
 
+// PrepareRegistration writes the PDP context that the modem will use during
+// the next EPS attach without starting a host data session. Some roaming SIMs
+// are rejected during registration when EC20 firmware restores a stale APN
+// after a baseband reboot, even when cellular data is disabled in VoCat.
+func (manager *Manager) PrepareRegistration(
+	ctx context.Context,
+	id string,
+	apn string,
+	ipVersion string,
+) error {
+	apn = strings.TrimSpace(apn)
+	if apn == "" {
+		return nil
+	}
+	if !ValidAPN(apn) {
+		return ErrInvalidNetworkAPN
+	}
+	ipVersion = normalizeIPVersion(ipVersion)
+	if ipVersion == "" {
+		return errors.New("IP version must be IP, IPV6, or IPV4V6")
+	}
+	state, err := manager.lookup(id)
+	if err != nil {
+		return err
+	}
+	state.opMu.Lock()
+	defer state.opMu.Unlock()
+	if err := manager.validateActive(id, state); err != nil {
+		return err
+	}
+	client, err := manager.clientLocked(ctx, state, manager.candidateFor(state))
+	if err != nil {
+		manager.setResult(id, state, nil, err)
+		return err
+	}
+	_, err = manager.command(ctx, client, fmt.Sprintf(`AT+CGDCONT=1,"%s","%s"`, ipVersion, apn))
+	manager.setResult(id, state, nil, err)
+	return err
+}
+
 func (manager *Manager) USBNetMode(ctx context.Context, id string) (USBNetMode, error) {
 	response, err := manager.ExecuteAT(ctx, id, `AT+QCFG="usbnet"`)
 	if err != nil {


### PR DESCRIPTION
## Summary

- detect EC20 modems that remain unregistered or searching for a bounded period
- restore the current SIM card policy's PDP context before retrying automatic registration
- escalate one unresolved registration episode to a single modem reboot
- restore the PDP context and registration request after the EC20 AT transport returns

## Root cause

Some EC20 firmware restores CID 1 to a stale PDP context after a baseband or cold reboot. The modem can remain in `CEREG` state 0 or 2 despite having usable radio coverage.

VoCat periodically refreshed and displayed this state but did not recover AT-based EC20 registration automatically. Manual operator re-registration could also be insufficient when the PDP context had not first been restored.

## Recovery behavior

For an EC20 with a ready SIM and enabled radio:

1. after two minutes in registration state 0 or 2, VoCat restores the card-specific PDP context and requests automatic registration
2. if the same episode remains unresolved for another three minutes, VoCat performs one modem reboot
3. after the AT transport returns, VoCat restores the PDP context and requests registration again

A successful registration, SIM change, airplane mode, or an inapplicable state resets the episode.

## Scope

This change only:

- applies automatic recovery to EC20 model identifiers
- handles prolonged registration states 0 and 2
- uses an already stored per-card APN and IP version
- performs at most one modem reboot per continuous failure episode
- programs the PDP context without enabling a host cellular data session

It does not:

- change operator selection policy or create a manual PLMN lock
- invent, infer, or hard-code an operator APN
- enable cellular data when the user has disabled it
- affect VoWiFi, IMS authentication, SMS decoding, eSIM profile switching, MBN selection, OpenStick native-QMI registration, or non-EC20 modems
- repeatedly reboot a modem while coverage remains unavailable

## Verification

- `go test ./cmd/vocat ./internal/device -run 'TestRegistrationRecovery|TestPrepareRegistration|TestReRegisterOperator|TestSetNetwork' -count=1`
- repository tests excluding the existing Windows-only `internal/qmiport` device-node test
- `go vet ./cmd/vocat ./internal/device`
- `git diff --check`

Validated on an MT3000 with an EC20 by forcing deregistration and observing automatic recovery from an unregistered state to roaming LTE registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for EC20 modems that remain unregistered while the SIM is ready and the radio is active.
  * The system attempts re-registration first, then escalates to a modem reboot if registration does not recover.
  * Data connection settings are re-prepared before registration retries.
  * Recovery runs automatically in the background with safeguards against unnecessary repeated reboots.

* **Bug Fixes**
  * Improved resilience against modem registration failures and prolonged connectivity loss.
  * Recovery actions verify the modem’s current status before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->