### PR TITLE
fix(vowifi): preserve fatal IKE notifications during EAP

### DIFF
--- a/internal/vowifi/ike/provider.go
+++ b/internal/vowifi/ike/provider.go
@@ -386,6 +386,12 @@ func (provider *Provider) start(ctx context.Context, request vowifi.TunnelReques
 	messageID := uint32(1)
 	currentPayloads := authResponsePayloads
 	for round := 0; round < 10; round++ {
+		// A responder may terminate EAP with an IKEv2 error Notify instead of
+		// another EAP payload. Preserve that protocol result rather than masking
+		// it as a missing payload type 48 parse error.
+		if err := rejectFatalNotifications(currentPayloads); err != nil {
+			return nil, fmt.Errorf("ike: IKE_AUTH EAP round %d: %w", round+1, err)
+		}
 		eapPayload, err := onePayload(currentPayloads, payloadEAP)
 		if err != nil {
 			return nil, fmt.Errorf("ike: IKE_AUTH EAP round %d: %w", round+1, err)
@@ -884,6 +890,11 @@ func rejectFatalNotifications(payloads []payload) error {
 				return &invalidKEPayloadError{group: binary.BigEndian.Uint16(data)}
 			}
 			return &invalidKEPayloadError{}
+		case notifyAuthenticationFailed:
+			return fmt.Errorf(
+				"%w: responder reported AUTHENTICATION_FAILED (Notify 24)",
+				vowifi.ErrEAPAuthenticationRejected,
+			)
 		}
 		if kind < 16384 {
 			return fmt.Errorf("ike: responder reported fatal notification %d", kind)

--- a/internal/vowifi/ike/provider_test.go
+++ b/internal/vowifi/ike/provider_test.go
@@ -39,6 +39,16 @@ func TestLegacyProposalFallbackIsLimitedToNegotiationFailures(t *testing.T) {
 	}
 }
 
+func TestRejectFatalNotificationsClassifiesAuthenticationFailed(t *testing.T) {
+	err := rejectFatalNotifications([]payload{makeNotify(notifyAuthenticationFailed, nil)})
+	if !errors.Is(err, vowifi.ErrEAPAuthenticationRejected) {
+		t.Fatalf("rejectFatalNotifications() error = %v", err)
+	}
+	if !strings.Contains(err.Error(), "AUTHENTICATION_FAILED (Notify 24)") {
+		t.Fatalf("rejectFatalNotifications() error = %q", err)
+	}
+}
+
 func (reader constantReader) Read(destination []byte) (int, error) {
 	for index := range destination {
 		destination[index] = reader.value

--- a/internal/vowifi/ike/wire.go
+++ b/internal/vowifi/ike/wire.go
@@ -68,6 +68,8 @@ const (
 	notifyNoProposal             = 14
 )
 
+const notifyAuthenticationFailed = 24
+
 var (
 	errMalformedPacket   = errors.New("ike: malformed packet")
 	errUnexpectedPacket  = errors.New("ike: unexpected packet")


### PR DESCRIPTION
## Summary

- inspect fatal IKE notifications before requiring the next EAP payload
- classify IKEv2 AUTHENTICATION_FAILED (Notify 24) as ErrEAPAuthenticationRejected
- preserve the EAP round context so runtime state reports the actual responder decision

## Problem

Some ePDGs terminate an in-progress EAP exchange with an IKEv2 error Notify and no EAP payload. The EAP loop currently calls onePayload first, masking the responder error as:

```
expected one payload type 48, got 0
```

This was reproduced against a Vodafone UK ePDG returning AUTHENTICATION_FAILED during IKE_AUTH. The typed error keeps the existing retry behavior while exposing the actionable authentication rejection.

## Testing

- `go test ./internal/vowifi/... -count=1`
- `go vet ./internal/vowifi/...`
- all Go packages except the known Windows-only `internal/qmiport` file-sharing failure
- `npm test`
- GL-MT3000 arm64 live verification: tunnel, IMS, and SMS all reached ready


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of fatal IKE authentication notifications during EAP exchanges.
  * Authentication failures are now reported with a specific authentication-rejected error instead of appearing as a missing EAP payload.
  * Error messages now identify the `AUTHENTICATION_FAILED` notification for clearer troubleshooting.

* **Tests**
  * Added coverage to verify correct classification and messaging of authentication rejection responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->