### PR TITLE
fix(vowifi): avoid single-fragment SKF payloads

### DIFF
--- a/internal/vowifi/ike/crypto.go
+++ b/internal/vowifi/ike/crypto.go
@@ -324,11 +324,22 @@ func encryptPayloadsFragmented(
 		chunks = append(chunks, plaintext[:take])
 		plaintext = plaintext[take:]
 	}
-	totalFragments := uint16(len(chunks))
-	if totalFragments == 0 {
-		totalFragments = 1
-		chunks = [][]byte{nil}
+	if len(chunks) <= 1 {
+		packet, err := encryptPayloads(
+			header,
+			inner,
+			suite,
+			encryptionKey,
+			integrityKey,
+			random,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return [][]byte{packet}, nil
 	}
+
+	totalFragments := uint16(len(chunks))
 
 	var packets [][]byte
 	for index, chunk := range chunks {

--- a/internal/vowifi/ike/crypto_single_fragment_test.go
+++ b/internal/vowifi/ike/crypto_single_fragment_test.go
@@ -1,0 +1,70 @@
+package ike
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRFC7383SmallPayloadStaysUnfragmented(t *testing.T) {
+	suite := legacyTestSuite()
+	encryptionKey := bytes.Repeat([]byte{0x11}, 16)
+	integrityKey := bytes.Repeat([]byte{0x22}, 20)
+
+	header := ikeHeader{
+		InitiatorSPI: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		ResponderSPI: [8]byte{8, 7, 6, 5, 4, 3, 2, 1},
+		Exchange:     exchangeIKEAuth,
+		Flags:        flagInitiator,
+		MessageID:    1,
+	}
+
+	inner := []payload{
+		{Type: payloadIDi, Body: []byte{3, 0, 0, 0, 'u', 's', 'e', 'r'}},
+		{Type: payloadEAP, Body: bytes.Repeat([]byte{0x33}, 64)},
+	}
+
+	packets, err := encryptPayloadsFragmented(
+		header,
+		inner,
+		suite,
+		encryptionKey,
+		integrityKey,
+		defaultIKEFragmentSize,
+		bytes.NewReader(bytes.Repeat([]byte{0x77}, 256)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(packets) != 1 {
+		t.Fatalf("got %d packets, want 1", len(packets))
+	}
+
+	hdr, _, err := parseIKEPacket(packets[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hdr.NextPayload != payloadEncrypted {
+		t.Fatalf(
+			"small protected exchange NextPayload = %d, want %d (payloadEncrypted)",
+			hdr.NextPayload,
+			payloadEncrypted,
+		)
+	}
+
+	decodedHeader, decoded, err := decryptPayloadsAny(
+		packets[0],
+		nil,
+		suite,
+		encryptionKey,
+		integrityKey,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if decodedHeader.MessageID != header.MessageID || len(decoded) != len(inner) {
+		t.Fatal("decrypted small exchange mismatch")
+	}
+}


### PR DESCRIPTION
根据 #118 中提出的修复方案整理了这个 PR。

当前在对端声明支持 RFC 7383 IKE Fragmentation 时，即使加密后的 Payload 最终只产生一个 chunk，也会发送 `SKF 1/1`。

这个 PR 按 issue 中的建议修改为：

* 如果最终只产生 1 个 chunk，则回退为普通 `SK`
* 只有实际需要 2 个及以上分片时才使用 `SKF`
* 保留原有多分片逻辑

同时增加了单分片场景的回归测试。

测试结果：

```text
TestRFC7383SmallPayloadStaysUnfragmented PASS
TestRFC7383FragmentationAndReassembly   PASS
go test ./internal/vowifi/...           PASS
```

另外已在新西兰 2degrees（PLMN 53024）真实 VoWiFi 环境中验证。修改前首个 IKE_AUTH 会以 `SKF 1/1` 发送并超时；修改后改为普通 `SK` 后可以继续完成后续 IKE / IMS 流程。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Small encrypted IKE payloads are now sent as a single, non-fragmented packet.
  - Empty plaintext no longer produces an empty fragment packet.
- **Tests**
  - Added coverage verifying correct encryption and decryption of small IKE exchanges, including payload and message ID handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->