### PR TITLE
fix(device): allow SMS storage index zero

### DIFF
--- a/internal/device/sms.go
+++ b/internal/device/sms.go
@@ -278,7 +278,7 @@ func (manager *Manager) DeleteSMSFromStorage(
 	storage string,
 	index int,
 ) error {
-	if index <= 0 {
+	if index < 0 {
 		return ErrSMSInvalidMessageIndex
 	}
 	storage = strings.ToUpper(strings.TrimSpace(storage))


### PR DESCRIPTION
修复 #121。

大疆模块的 Quectel 模组会合法使用 SMS storage index `0`，例如短信可能出现在 `ME index 0`。

当前 `DeleteSMSFromStorage()` 使用：

```go
if index <= 0 {
    return ErrSMSInvalidMessageIndex
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SMS storage deletion so messages at index 0 can be deleted successfully.
  * Negative message indexes continue to be rejected as invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->