### PR TITLE
fix(sms): clear modem storage after a successful sync

### DIFF
--- a/internal/developer/settings.go
+++ b/internal/developer/settings.go
@@ -23,13 +23,14 @@ func Enabled(ctx context.Context, database *store.Store) bool {
 }
 
 const (
-	EnabledSettingKey     = "developer.enabled"
-	DeviceLimitSettingKey = "developer.device_limit"
-	SMSHourlyLimitKey     = "developer.sms_hourly_limit"
-	DefaultDeviceLimit    = 5
-	MaxDeviceLimit        = 10
-	DefaultSMSHourlyLimit = 10
-	MaxSMSHourlyLimit     = 20
+	EnabledSettingKey        = "developer.enabled"
+	DeviceLimitSettingKey    = "developer.device_limit"
+	SMSHourlyLimitKey        = "developer.sms_hourly_limit"
+	AutoClearModemStorageKey = "sms.auto_clear_modem_storage"
+	DefaultDeviceLimit       = 5
+	MaxDeviceLimit           = 10
+	DefaultSMSHourlyLimit    = 10
+	MaxSMSHourlyLimit        = 20
 )
 
 func DeviceLimit(ctx context.Context, database *store.Store, enabled bool) int {
@@ -91,6 +92,34 @@ func SetSMSHourlyLimit(ctx context.Context, database *store.Store, limit int) er
 		return err
 	}
 	return database.UpsertAppSetting(ctx, store.AppSetting{Key: SMSHourlyLimitKey, Value: value})
+}
+
+// AutoClearModemStorage reports whether a successful SMS ingest should delete
+// the modem SM/ME copy. A missing setting is treated as enabled so existing
+// deployments start reclaiming the small ME mailbox after upgrade.
+func AutoClearModemStorage(ctx context.Context, database *store.Store) bool {
+	if database == nil {
+		return true
+	}
+	setting, err := database.AppSetting(ctx, AutoClearModemStorageKey)
+	if err != nil {
+		return true
+	}
+	var document struct {
+		Enabled *bool `json:"enabled"`
+	}
+	if json.Unmarshal(setting.Value, &document) != nil || document.Enabled == nil {
+		return true
+	}
+	return *document.Enabled
+}
+
+func SetAutoClearModemStorage(ctx context.Context, database *store.Store, enabled bool) error {
+	value, err := json.Marshal(map[string]bool{"enabled": enabled})
+	if err != nil {
+		return err
+	}
+	return database.UpsertAppSetting(ctx, store.AppSetting{Key: AutoClearModemStorageKey, Value: value})
 }
 
 // ResetExperimental restores every mutable developer-only setting. It is

--- a/internal/developer/settings_test.go
+++ b/internal/developer/settings_test.go
@@ -82,6 +82,30 @@ func TestSetDeviceLimitValidatesRange(t *testing.T) {
 	}
 }
 
+func TestAutoClearModemStorageDefaultsEnabled(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, filepath.Join(t.TempDir(), "vocat.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	if !AutoClearModemStorage(ctx, database) {
+		t.Fatal("missing setting should default to enabled")
+	}
+	if err := SetAutoClearModemStorage(ctx, database, false); err != nil {
+		t.Fatal(err)
+	}
+	if AutoClearModemStorage(ctx, database) {
+		t.Fatal("explicit false should disable auto-clear")
+	}
+	if err := SetAutoClearModemStorage(ctx, database, true); err != nil {
+		t.Fatal(err)
+	}
+	if !AutoClearModemStorage(ctx, database) {
+		t.Fatal("explicit true should enable auto-clear")
+	}
+}
+
 func TestSetSMSHourlyLimitValidatesRange(t *testing.T) {
 	ctx := context.Background()
 	database, err := store.Open(ctx, filepath.Join(t.TempDir(), "vocat.db"))

--- a/internal/device/sms.go
+++ b/internal/device/sms.go
@@ -168,41 +168,50 @@ var smsListStorages = []string{"SM", "ME"}
 func (manager *Manager) ListSMS(
 	ctx context.Context,
 	id string,
-) ([]SMSMessage, error) {
+) (SMSListing, error) {
 	state, err := manager.lookup(id)
 	if err != nil {
-		return nil, err
+		return SMSListing{}, err
 	}
 	state.opMu.Lock()
 	defer state.opMu.Unlock()
 	if err := manager.validateActive(id, state); err != nil {
-		return nil, err
+		return SMSListing{}, err
 	}
 	client, err := manager.clientLocked(ctx, state, manager.candidateFor(state))
 	if err != nil {
 		manager.setResult(id, state, nil, err)
-		return nil, err
+		return SMSListing{}, err
 	}
 	if _, err := manager.command(ctx, client, "AT+CMGF=0"); err != nil {
 		manager.setResult(id, state, nil, err)
-		return nil, err
+		return SMSListing{}, err
 	}
-	var messages []SMSMessage
+	listing := SMSListing{}
 	var lastErr error
 	listed := false
 	for _, storage := range smsListStorages {
 		// Select this storage for reading (mem1 only, so send/receive routing is
 		// untouched). An unsupported storage reports an error; skip it rather than
 		// fail the whole listing.
-		if _, err := manager.command(
+		response, err := manager.command(
 			ctx,
 			client,
 			fmt.Sprintf("AT+CPMS=%q", storage),
-		); err != nil {
+		)
+		if err != nil {
 			lastErr = err
 			continue
 		}
-		response, err := manager.command(ctx, client, "AT+CMGL=4")
+		if area, ok := parseSelectedCPMSUsage(response); ok {
+			switch storage {
+			case "SM":
+				listing.Storage.SM = area
+			case "ME":
+				listing.Storage.ME = area
+			}
+		}
+		response, err = manager.command(ctx, client, "AT+CMGL=4")
 		if err != nil {
 			lastErr = err
 			continue
@@ -210,15 +219,22 @@ func (manager *Manager) ListSMS(
 		listed = true
 		for _, message := range parseCMGL(response) {
 			message.Storage = storage
-			messages = append(messages, message)
+			listing.Messages = append(listing.Messages, message)
 		}
 	}
 	if !listed && lastErr != nil {
 		manager.setResult(id, state, nil, lastErr)
-		return nil, lastErr
+		return SMSListing{}, lastErr
+	}
+	// New MT SMS follows mem1. Leave SM selected so a burst between scans
+	// lands in the larger SIM mailbox instead of the 23-slot ME area.
+	if restore, restoreErr := manager.command(ctx, client, `AT+CPMS="SM"`); restoreErr == nil {
+		if area, ok := parseSelectedCPMSUsage(restore); ok {
+			listing.Storage.SM = area
+		}
 	}
 	manager.setResult(id, state, nil, nil)
-	return messages, nil
+	return listing, nil
 }
 
 func (manager *Manager) ReadSMS(
@@ -447,6 +463,28 @@ func parseCMGR(index int, response modem.Response) (SMSMessage, error) {
 		return message, nil
 	}
 	return SMSMessage{}, errors.New("modem did not return a CMGR record")
+}
+
+func parseSelectedCPMSUsage(response modem.Response) (SMSStorageArea, bool) {
+	fields := csvValues(valueAfterPrefix(response, "+CPMS:"))
+	start := 0
+	if len(fields) >= 3 && !decimalField(fields[0]) {
+		start = 1
+	}
+	if start+1 >= len(fields) {
+		return SMSStorageArea{}, false
+	}
+	used, usedOK := parseDecimal(fields[start])
+	total, totalOK := parseDecimal(fields[start+1])
+	if !usedOK || !totalOK || used < 0 || total < 0 {
+		return SMSStorageArea{}, false
+	}
+	return SMSStorageArea{Used: used, Total: total}, true
+}
+
+func decimalField(value string) bool {
+	_, ok := parseDecimal(value)
+	return ok
 }
 
 func parseSMSStorageStatus(value string) SMSStorageStatus {

--- a/internal/device/sms_test.go
+++ b/internal/device/sms_test.go
@@ -271,7 +271,7 @@ func TestManagerListReadAndDeleteSMS(t *testing.T) {
 	const ucs2PDU = "000405912143F5000842102030405000044F60597D"
 	client := &transcriptClient{steps: []clientStep{
 		{command: "AT+CMGF=0", response: okResponse()},
-		{command: `AT+CPMS="SM"`, response: okResponse()},
+		{command: `AT+CPMS="SM"`, response: okResponse("+CPMS: 2,40,0,23,2,40")},
 		{
 			command: "AT+CMGL=4",
 			response: okResponse(
@@ -281,8 +281,9 @@ func TestManagerListReadAndDeleteSMS(t *testing.T) {
 				ucs2PDU,
 			),
 		},
-		{command: `AT+CPMS="ME"`, response: okResponse()},
+		{command: `AT+CPMS="ME"`, response: okResponse("+CPMS: 0,23,2,40,2,40")},
 		{command: "AT+CMGL=4", response: okResponse()},
+		{command: `AT+CPMS="SM"`, response: okResponse("+CPMS: 2,40,0,23,2,40")},
 		{command: "AT+CMGF=0", response: okResponse()},
 		{
 			command: "AT+CMGR=7",
@@ -295,9 +296,14 @@ func TestManagerListReadAndDeleteSMS(t *testing.T) {
 	}}
 	manager, id := newStartedTestManager(t, client)
 
-	messages, err := manager.ListSMS(context.Background(), id)
+	listing, err := manager.ListSMS(context.Background(), id)
 	if err != nil {
 		t.Fatalf("ListSMS: %v", err)
+	}
+	messages := listing.Messages
+	if listing.Storage.SM != (SMSStorageArea{Used: 2, Total: 40}) ||
+		listing.Storage.ME != (SMSStorageArea{Used: 0, Total: 23}) {
+		t.Fatalf("storage = %#v", listing.Storage)
 	}
 	if len(messages) != 2 ||
 		messages[0].Index != 7 ||
@@ -370,4 +376,18 @@ func TestManagerSendSMSRequiresMessageReference(t *testing.T) {
 		t.Fatalf("result = %#v", result)
 	}
 	client.assertDone(t)
+}
+
+func TestParseSelectedCPMSUsage(t *testing.T) {
+	area, ok := parseSelectedCPMSUsage(okResponse("+CPMS: 23,23,23,23,23,23"))
+	if !ok || area != (SMSStorageArea{Used: 23, Total: 23}) {
+		t.Fatalf("select form = %#v, %v", area, ok)
+	}
+	area, ok = parseSelectedCPMSUsage(okResponse(`+CPMS: "SM",0,40,"ME",23,23,"MT",23,23`))
+	if !ok || area != (SMSStorageArea{Used: 0, Total: 40}) {
+		t.Fatalf("named form = %#v, %v", area, ok)
+	}
+	if _, ok = parseSelectedCPMSUsage(okResponse()); ok {
+		t.Fatal("empty CPMS response should not parse")
+	}
 }

--- a/internal/device/types.go
+++ b/internal/device/types.go
@@ -165,6 +165,25 @@ const (
 	SMSEncodingUnknown  SMSEncoding = "unknown"
 )
 
+type SMSStorageArea struct {
+	Used  int `json:"used"`
+	Total int `json:"total"`
+}
+
+type SMSStorageUsage struct {
+	SM SMSStorageArea `json:"sm"`
+	ME SMSStorageArea `json:"me"`
+}
+
+func (usage SMSStorageUsage) Known() bool {
+	return usage.SM.Total > 0 || usage.ME.Total > 0
+}
+
+type SMSListing struct {
+	Messages []SMSMessage
+	Storage  SMSStorageUsage
+}
+
 type SMSStorageStatus string
 
 const (

--- a/internal/server/developer_settings.go
+++ b/internal/server/developer_settings.go
@@ -16,14 +16,15 @@ func (s *Server) handleDeveloperSettings(w http.ResponseWriter, r *http.Request)
 		s.writeDeveloperSettings(w, r)
 	case http.MethodPut:
 		var request struct {
-			DeviceLimit    *int `json:"device_limit"`
-			SMSHourlyLimit *int `json:"sms_hourly_limit"`
+			DeviceLimit           *int  `json:"device_limit"`
+			SMSHourlyLimit        *int  `json:"sms_hourly_limit"`
+			AutoClearModemStorage *bool `json:"auto_clear_modem_storage"`
 		}
 		if err := s.decodeJSON(w, r, &request); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
-		if request.DeviceLimit == nil && request.SMSHourlyLimit == nil {
+		if request.DeviceLimit == nil && request.SMSHourlyLimit == nil && request.AutoClearModemStorage == nil {
 			writeError(w, http.StatusBadRequest, "invalid_request", "at least one developer setting is required")
 			return
 		}
@@ -49,6 +50,13 @@ func (s *Server) handleDeveloperSettings(w http.ResponseWriter, r *http.Request)
 			}
 			s.recordAudit(r.Context(), "admin", "settings.developer.sms_hourly_limit", "settings", "developer", "success", "global SMS hourly limit updated")
 		}
+		if request.AutoClearModemStorage != nil {
+			if err := developer.SetAutoClearModemStorage(r.Context(), s.store, *request.AutoClearModemStorage); err != nil {
+				writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+				return
+			}
+			s.recordAudit(r.Context(), "admin", "settings.sms.auto_clear_modem_storage", "settings", "sms", "success", "modem SMS auto-clear updated")
+		}
 		s.writeDeveloperSettings(w, r)
 	default:
 		w.Header().Set("Allow", "GET, PUT")
@@ -64,5 +72,6 @@ func (s *Server) writeDeveloperSettings(w http.ResponseWriter, r *http.Request) 
 		"sms_hourly_limit":         developer.SMSHourlyLimit(r.Context(), s.store),
 		"default_sms_hourly_limit": developer.DefaultSMSHourlyLimit,
 		"max_sms_hourly_limit":     developer.MaxSMSHourlyLimit,
+		"auto_clear_modem_storage": developer.AutoClearModemStorage(r.Context(), s.store),
 	}})
 }

--- a/internal/server/developer_settings.go
+++ b/internal/server/developer_settings.go
@@ -52,7 +52,7 @@ func (s *Server) handleDeveloperSettings(w http.ResponseWriter, r *http.Request)
 		}
 		if request.AutoClearModemStorage != nil {
 			if err := developer.SetAutoClearModemStorage(r.Context(), s.store, *request.AutoClearModemStorage); err != nil {
-				writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+				s.writeStoreError(w, err)
 				return
 			}
 			s.recordAudit(r.Context(), "admin", "settings.sms.auto_clear_modem_storage", "settings", "sms", "success", "modem SMS auto-clear updated")

--- a/internal/server/developer_settings_test.go
+++ b/internal/server/developer_settings_test.go
@@ -50,3 +50,27 @@ func TestDeveloperSettingsUpdatesGlobalSMSLimit(t *testing.T) {
 		t.Fatalf("SMS hourly limit = %d, want 17", got)
 	}
 }
+
+func TestDeveloperSettingsUpdatesAutoClearModemStorage(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	enabled, _ := json.Marshal(map[string]bool{"enabled": true})
+	if err := database.UpsertAppSetting(ctx, store.AppSetting{Key: developer.EnabledSettingKey, Value: enabled}); err != nil {
+		t.Fatal(err)
+	}
+	server := &Server{store: database, developerEnabled: true, logger: regionTestLogger(), maxRequestBodyBytes: 4096}
+	request := httptest.NewRequest(http.MethodPut, "/api/settings/developer", strings.NewReader(`{"auto_clear_modem_storage":false}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	server.handleDeveloperSettings(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", response.Code, response.Body.String())
+	}
+	if developer.AutoClearModemStorage(ctx, database) {
+		t.Fatal("auto-clear should be disabled")
+	}
+}

--- a/internal/server/device_api.go
+++ b/internal/server/device_api.go
@@ -44,7 +44,7 @@ type DeviceController interface {
 	ReRegisterOperator(context.Context, string) (device.OperatorSelection, error)
 	ScanOperators(context.Context, string) (device.OperatorScanResult, error)
 	SendSMS(context.Context, string, string, string) (device.SMSSendResult, error)
-	ListSMS(context.Context, string) ([]device.SMSMessage, error)
+	ListSMS(context.Context, string) (device.SMSListing, error)
 	ReadSMS(context.Context, string, int) (device.SMSMessage, error)
 	DeleteSMS(context.Context, string, int) error
 	DeleteSMSFromStorage(context.Context, string, string, int) error
@@ -1972,6 +1972,9 @@ func (s *Server) configuredDeviceSummary(
 	result["proxy_port"] = config.ProxyPort
 	result["esim_transport"] = config.ESIMTransport
 	result["sms_enabled"] = config.SMSEnabled
+	if usage, ok := s.smsStorageUsage(config.ID); ok {
+		result["sms_storage"] = usage
+	}
 	result["network_enabled"] = config.NetworkEnabled
 	result["developer_enabled"] = s.developerActive(context.Background())
 	dataRuntime := s.cellularDataRuntime().status(config.ID, config.NetworkEnabled)

--- a/internal/server/region_test.go
+++ b/internal/server/region_test.go
@@ -93,8 +93,8 @@ func (f fakeDeviceController) ScanOperators(context.Context, string) (device.Ope
 func (f fakeDeviceController) SendSMS(context.Context, string, string, string) (device.SMSSendResult, error) {
 	return device.SMSSendResult{}, nil
 }
-func (f fakeDeviceController) ListSMS(context.Context, string) ([]device.SMSMessage, error) {
-	return append([]device.SMSMessage(nil), f.smsMessages...), f.smsErr
+func (f fakeDeviceController) ListSMS(context.Context, string) (device.SMSListing, error) {
+	return device.SMSListing{Messages: append([]device.SMSMessage(nil), f.smsMessages...)}, f.smsErr
 }
 func (f fakeDeviceController) ReadSMS(context.Context, string, int) (device.SMSMessage, error) {
 	return device.SMSMessage{}, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"vocat/internal/auth"
+	"vocat/internal/device"
 	"vocat/internal/exportproxy"
 	"vocat/internal/extensions"
 	"vocat/internal/httpsmode"
@@ -89,6 +90,8 @@ type Server struct {
 	lookupPublicIP            func(context.Context, string) (exportproxy.PublicIPInfo, error)
 	automaticTasks            *automaticTaskScheduler
 	smsSyncMu                 sync.Mutex
+	smsStorageMu              sync.Mutex
+	smsStorage                map[string]device.SMSStorageUsage
 	cellularDataOnce          sync.Once
 	cellularDataMonitorOnce   sync.Once
 	cellularDataEventOnce     sync.Once
@@ -145,6 +148,7 @@ func New(options Options) (*Server, error) {
 		netTraffic:          newLiveNetTracker(),
 		hostStats:           newHostStatsSampler(),
 		publicIPs:           make(map[string]cachedPublicIP),
+		smsStorage:          make(map[string]device.SMSStorageUsage),
 		lookupPublicIP:      exportproxy.LookupPublicIP,
 		updateCheck:         update.CheckLatest,
 		updateApply:         update.ApplyLatest,

--- a/internal/server/settings_api.go
+++ b/internal/server/settings_api.go
@@ -95,6 +95,9 @@ func (s *Server) routeSettingsAPI(
 	case "settings/logging":
 		s.handleLoggingSettings(w, r)
 		return true
+	case "settings/sms":
+		s.handleSMSSettings(w, r)
+		return true
 	}
 	segments := splitAPIPath(cleanPath)
 	if len(segments) == 4 &&

--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -737,8 +737,10 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 					DischargeTime:     message.DischargeTimestamp,
 					ReceivedAt:        time.Now().UTC(),
 				})
-				if applyErr != nil && !errors.Is(applyErr, store.ErrNotFound) {
-					s.logger.Warn("apply modem SMS delivery report failed", "device_id", config.ID, "error", applyErr)
+				if applyErr != nil {
+					if !errors.Is(applyErr, store.ErrNotFound) {
+						s.logger.Warn("apply modem SMS delivery report failed", "device_id", config.ID, "error", applyErr)
+					}
 					continue
 				}
 				if autoClear {

--- a/internal/server/sms_api.go
+++ b/internal/server/sms_api.go
@@ -23,6 +23,38 @@ type imsSMSController interface {
 	SendSMS(context.Context, string, vowifi.SMSSubmitRequest) (vowifi.SMSSubmitResult, error)
 }
 
+func (s *Server) handleSMSSettings(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, map[string]any{"data": map[string]any{
+			"auto_clear_modem_storage": developer.AutoClearModemStorage(r.Context(), s.store),
+		}})
+	case http.MethodPut:
+		var request struct {
+			AutoClearModemStorage *bool `json:"auto_clear_modem_storage"`
+		}
+		if err := s.decodeJSON(w, r, &request); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		if request.AutoClearModemStorage == nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "auto_clear_modem_storage is required")
+			return
+		}
+		if err := developer.SetAutoClearModemStorage(r.Context(), s.store, *request.AutoClearModemStorage); err != nil {
+			s.writeStoreError(w, err)
+			return
+		}
+		s.recordAudit(r.Context(), "admin", "settings.sms.auto_clear_modem_storage", "settings", "sms", "success", "modem SMS auto-clear updated")
+		writeJSON(w, http.StatusOK, map[string]any{"data": map[string]any{
+			"auto_clear_modem_storage": developer.AutoClearModemStorage(r.Context(), s.store),
+		}})
+	default:
+		w.Header().Set("Allow", "GET, PUT")
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+	}
+}
+
 func (s *Server) routeSMSAPI(w http.ResponseWriter, r *http.Request, cleanPath string) bool {
 	switch cleanPath {
 	case "sms/contacts":
@@ -659,12 +691,14 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 			}
 		}
 		listContext, cancelList := context.WithTimeout(ctx, 30*time.Second)
-		messages, err := s.devices.ListSMS(listContext, physicalID)
+		listing, err := s.devices.ListSMS(listContext, physicalID)
 		cancelList()
 		if err != nil {
 			s.logger.Debug("modem SMS synchronization skipped", "device_id", config.ID, "error", err)
 			continue
 		}
+		s.rememberSMSStorage(config.ID, listing.Storage)
+		messages := listing.Messages
 		currentEntry, currentErr := s.devices.Get(physicalID)
 		if currentErr != nil || !currentEntry.Discovered {
 			s.logger.Debug("modem SMS synchronization lost device identity", "device_id", config.ID, "error", currentErr)
@@ -685,6 +719,8 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 			config.ModemIMEI,
 		)
 		concatSources := modemSMSConcatSources(messages)
+		autoClear := developer.AutoClearModemStorage(ctx, s.store)
+		var clearSlots []modemSMSSlot
 		for _, message := range messages {
 			if message.Direction == device.SMSDirectionStatusReport &&
 				message.MessageReference != nil && message.StatusCode != nil {
@@ -703,6 +739,10 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 				})
 				if applyErr != nil && !errors.Is(applyErr, store.ErrNotFound) {
 					s.logger.Warn("apply modem SMS delivery report failed", "device_id", config.ID, "error", applyErr)
+					continue
+				}
+				if autoClear {
+					clearSlots = appendModemSMSSlot(clearSlots, message)
 				}
 				continue
 			}
@@ -758,7 +798,12 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 			})
 			if saveErr != nil {
 				s.logger.Warn("persist modem SMS failed", "category", "sms", "device_id", config.ID, "raw_error", saveErr)
-			} else if saved := saveResult.Message; saveResult.Inserted && saved.Direction == "inbound" &&
+				continue
+			}
+			if autoClear {
+				clearSlots = appendModemSMSSlot(clearSlots, message)
+			}
+			if saved := saveResult.Message; saveResult.Inserted && saved.Direction == "inbound" &&
 				store.ConcatSMSReadyToNotify(saved.MessageID, saved.Extra) {
 				s.logger.Info("cellular SMS received",
 					"category", "sms", "event", "sms.received",
@@ -768,6 +813,59 @@ func (s *Server) syncModemSMS(ctx context.Context, onlyDevice string) {
 				)
 			}
 		}
+		if autoClear {
+			s.clearPersistedModemSMS(ctx, physicalID, config.ID, clearSlots)
+		}
+	}
+}
+
+type modemSMSSlot struct {
+	storage string
+	index   int
+}
+
+func appendModemSMSSlot(slots []modemSMSSlot, message device.SMSMessage) []modemSMSSlot {
+	storage := strings.ToUpper(strings.TrimSpace(message.Storage))
+	if (storage != "SM" && storage != "ME") || message.Index < 0 {
+		return slots
+	}
+	for _, existing := range slots {
+		if existing.storage == storage && existing.index == message.Index {
+			return slots
+		}
+	}
+	return append(slots, modemSMSSlot{storage: storage, index: message.Index})
+}
+
+func sortModemSMSSlotsDescending(slots []modemSMSSlot) {
+	sort.SliceStable(slots, func(i, j int) bool {
+		if slots[i].storage != slots[j].storage {
+			return slots[i].storage > slots[j].storage
+		}
+		return slots[i].index > slots[j].index
+	})
+}
+
+func (s *Server) clearPersistedModemSMS(ctx context.Context, physicalID, configID string, slots []modemSMSSlot) {
+	if len(slots) == 0 || s.devices == nil {
+		return
+	}
+	sortModemSMSSlotsDescending(slots)
+	for _, slot := range slots {
+		deleteContext, cancelDelete := context.WithTimeout(ctx, 10*time.Second)
+		err := s.devices.DeleteSMSFromStorage(deleteContext, physicalID, slot.storage, slot.index)
+		cancelDelete()
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Warn(
+					"clear persisted modem SMS failed",
+					"category", "sms", "device_id", configID,
+					"storage", slot.storage, "index", slot.index, "error", err,
+				)
+			}
+			continue
+		}
+		s.noteSMSStorageFreed(configID, slot.storage)
 	}
 }
 
@@ -942,11 +1040,13 @@ func (s *Server) deleteModemSMS(ctx context.Context, stored store.SMSMessage) er
 		return device.ErrNotFound
 	}
 	listContext, cancelList := context.WithTimeout(ctx, 30*time.Second)
-	modemMessages, err := s.devices.ListSMS(listContext, physicalID)
+	listing, err := s.devices.ListSMS(listContext, physicalID)
 	cancelList()
 	if err != nil {
 		return fmt.Errorf("list modem SMS before deletion: %w", err)
 	}
+	s.rememberSMSStorage(config.ID, listing.Storage)
+	modemMessages := listing.Messages
 	concatSources := modemSMSConcatSources(modemMessages)
 	locations := make(map[string]device.SMSMessage)
 	for _, message := range modemMessages {
@@ -1075,4 +1175,51 @@ func (s *Server) writeStoreError(w http.ResponseWriter, err error) {
 	}
 	s.logger.Error("database operation failed", "category", "system", "event", "store.operation_failed", "raw_error", err)
 	writeError(w, http.StatusInternalServerError, "database_error", "the database operation failed")
+}
+
+func (s *Server) rememberSMSStorage(configID string, usage device.SMSStorageUsage) {
+	if s == nil || !usage.Known() {
+		return
+	}
+	s.smsStorageMu.Lock()
+	defer s.smsStorageMu.Unlock()
+	if s.smsStorage == nil {
+		s.smsStorage = make(map[string]device.SMSStorageUsage)
+	}
+	s.smsStorage[configID] = usage
+}
+
+func (s *Server) smsStorageUsage(configID string) (device.SMSStorageUsage, bool) {
+	if s == nil {
+		return device.SMSStorageUsage{}, false
+	}
+	s.smsStorageMu.Lock()
+	defer s.smsStorageMu.Unlock()
+	usage, ok := s.smsStorage[configID]
+	return usage, ok && usage.Known()
+}
+
+func (s *Server) noteSMSStorageFreed(configID, storage string) {
+	if s == nil {
+		return
+	}
+	s.smsStorageMu.Lock()
+	defer s.smsStorageMu.Unlock()
+	usage, ok := s.smsStorage[configID]
+	if !ok {
+		return
+	}
+	switch strings.ToUpper(strings.TrimSpace(storage)) {
+	case "SM":
+		if usage.SM.Used > 0 {
+			usage.SM.Used--
+		}
+	case "ME":
+		if usage.ME.Used > 0 {
+			usage.ME.Used--
+		}
+	default:
+		return
+	}
+	s.smsStorage[configID] = usage
 }

--- a/internal/server/sms_api_test.go
+++ b/internal/server/sms_api_test.go
@@ -27,10 +27,10 @@ type smsDeletionController struct {
 	deleted        []string
 }
 
-func (controller *smsDeletionController) ListSMS(context.Context, string) ([]device.SMSMessage, error) {
+func (controller *smsDeletionController) ListSMS(context.Context, string) (device.SMSListing, error) {
 	controller.mu.Lock()
 	defer controller.mu.Unlock()
-	return append([]device.SMSMessage(nil), controller.storedMessages...), nil
+	return device.SMSListing{Messages: append([]device.SMSMessage(nil), controller.storedMessages...)}, nil
 }
 
 func (controller *smsDeletionController) DeleteSMSFromStorage(
@@ -405,21 +405,21 @@ func TestDeleteSMSRemovesModemCopyBeforeDatabaseRow(t *testing.T) {
 		t.Fatalf("initial stored messages = %#v, %v", stored, err)
 	}
 	deletedID := stored[0].ID
+	controller.mu.Lock()
+	syncDeleted := append([]string(nil), controller.deleted...)
+	remainingAfterSync := len(controller.storedMessages)
+	controller.mu.Unlock()
+	sort.Strings(syncDeleted)
+	wantDeleted := []string{"ME:1", "ME:2", "ME:3", "SM:1", "SM:2", "SM:3"}
+	if strings.Join(syncDeleted, ",") != strings.Join(wantDeleted, ",") || remainingAfterSync != 0 {
+		t.Fatalf("sync modem deletion = %v, remaining = %d", syncDeleted, remainingAfterSync)
+	}
 
 	request := httptest.NewRequest(http.MethodDelete, "/api/sms/messages/"+strconv.FormatInt(deletedID, 10), nil)
 	response := httptest.NewRecorder()
 	server.handleSMSMessage(response, request, strconv.FormatInt(deletedID, 10))
 	if response.Code != http.StatusOK {
 		t.Fatalf("delete status = %d, body = %s", response.Code, response.Body.String())
-	}
-	controller.mu.Lock()
-	deleted := append([]string(nil), controller.deleted...)
-	remainingOnModem := len(controller.storedMessages)
-	controller.mu.Unlock()
-	sort.Strings(deleted)
-	wantDeleted := []string{"ME:1", "ME:2", "ME:3", "SM:1", "SM:2", "SM:3"}
-	if strings.Join(deleted, ",") != strings.Join(wantDeleted, ",") || remainingOnModem != 0 {
-		t.Fatalf("modem deletion = %v, remaining = %d", deleted, remainingOnModem)
 	}
 
 	server.syncModemSMS(ctx, deviceID)
@@ -433,6 +433,154 @@ func TestDeleteSMSRemovesModemCopyBeforeDatabaseRow(t *testing.T) {
 	}
 	if logs := hub.History(100, slog.LevelInfo, "cellular SMS received"); len(logs) != 1 {
 		t.Fatalf("sms.received logs after delete and resync = %d, want 1", len(logs))
+	}
+}
+
+func TestSyncModemSMSClearsPersistedModemSlots(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	const (
+		deviceID = "ec20-1"
+		imei     = "867394042309830"
+	)
+	if err := database.UpsertDevice(ctx, store.Device{
+		ID: deviceID, Name: "EC20", DeviceType: store.DeviceTypePCIeEC20EC25,
+		ModemIMEI: imei, SMSEnabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	receivedAt := time.Unix(1_700_000_000, 0).UTC()
+	controller := &smsDeletionController{
+		fakeDeviceController: fakeDeviceController{entry: device.Device{
+			ID: deviceID, Discovered: true,
+			Snapshot: &device.Snapshot{DeviceID: deviceID, IMEI: imei, IMSI: "23433"},
+		}},
+		storedMessages: []device.SMSMessage{{
+			Index: 4, Storage: "ME", StorageStatus: device.SMSStatusReceivedUnread,
+			Direction: device.SMSDirectionReceived, From: "+447700900123", Text: "hello",
+			Encoding: device.SMSEncodingGSM7PDU, ServiceCenterTimestamp: &receivedAt, RawPDU: "ME-hello",
+		}},
+	}
+	server := &Server{store: database, logger: regionTestLogger(), devices: controller}
+	server.syncModemSMS(ctx, deviceID)
+	controller.mu.Lock()
+	remaining := len(controller.storedMessages)
+	deleted := append([]string(nil), controller.deleted...)
+	controller.mu.Unlock()
+	if remaining != 0 || strings.Join(deleted, ",") != "ME:4" {
+		t.Fatalf("remaining = %d, deleted = %v", remaining, deleted)
+	}
+	stored, err := database.ListSMSMessages(ctx, store.SMSFilter{DeviceID: deviceID})
+	if err != nil || len(stored) != 1 || stored[0].Body != "hello" {
+		t.Fatalf("stored = %#v, %v", stored, err)
+	}
+}
+
+func TestSyncModemSMSKeepsModemSlotsWhenAutoClearDisabled(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	if err := developer.SetAutoClearModemStorage(ctx, database, false); err != nil {
+		t.Fatal(err)
+	}
+	const deviceID = "ec20-1"
+	if err := database.UpsertDevice(ctx, store.Device{
+		ID: deviceID, Name: "EC20", DeviceType: store.DeviceTypePCIeEC20EC25,
+		ModemIMEI: "867394042309830", SMSEnabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	receivedAt := time.Unix(1_700_000_000, 0).UTC()
+	controller := &smsDeletionController{
+		fakeDeviceController: fakeDeviceController{entry: device.Device{
+			ID: deviceID, Discovered: true,
+			Snapshot: &device.Snapshot{DeviceID: deviceID, IMEI: "867394042309830", IMSI: "23433"},
+		}},
+		storedMessages: []device.SMSMessage{{
+			Index: 4, Storage: "ME", StorageStatus: device.SMSStatusReceivedUnread,
+			Direction: device.SMSDirectionReceived, From: "+447700900123", Text: "hello",
+			Encoding: device.SMSEncodingGSM7PDU, ServiceCenterTimestamp: &receivedAt, RawPDU: "ME-hello",
+		}},
+	}
+	server := &Server{store: database, logger: regionTestLogger(), devices: controller}
+	server.syncModemSMS(ctx, deviceID)
+	controller.mu.Lock()
+	remaining := len(controller.storedMessages)
+	deleted := len(controller.deleted)
+	controller.mu.Unlock()
+	if remaining != 1 || deleted != 0 {
+		t.Fatalf("remaining = %d, deleted = %d", remaining, deleted)
+	}
+}
+
+func TestSyncModemSMSDoesNotClearUnpersistedMessages(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	const deviceID = "ec20-1"
+	if err := database.UpsertDevice(ctx, store.Device{
+		ID: deviceID, Name: "EC20", DeviceType: store.DeviceTypePCIeEC20EC25, SMSEnabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	controller := &smsDeletionController{
+		fakeDeviceController: fakeDeviceController{entry: device.Device{
+			ID: deviceID, Discovered: true,
+			Snapshot: &device.Snapshot{DeviceID: deviceID, IMEI: "867394042309830"},
+		}},
+		storedMessages: []device.SMSMessage{{
+			Index: 9, Storage: "ME", StorageStatus: device.SMSStatusReceivedUnread,
+			Direction: device.SMSDirectionReceived, Text: "no peer",
+			Encoding: device.SMSEncodingGSM7PDU, RawPDU: "orphan",
+		}},
+	}
+	server := &Server{store: database, logger: regionTestLogger(), devices: controller}
+	server.syncModemSMS(ctx, deviceID)
+	controller.mu.Lock()
+	remaining := len(controller.storedMessages)
+	deleted := len(controller.deleted)
+	controller.mu.Unlock()
+	if remaining != 1 || deleted != 0 {
+		t.Fatalf("remaining = %d, deleted = %d", remaining, deleted)
+	}
+	stored, err := database.ListSMSMessages(ctx, store.SMSFilter{DeviceID: deviceID})
+	if err != nil || len(stored) != 0 {
+		t.Fatalf("stored = %#v, %v", stored, err)
+	}
+}
+
+func TestSMSSettingsAPITogglesAutoClear(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	server := &Server{store: database, logger: regionTestLogger(), maxRequestBodyBytes: 4096}
+	get := httptest.NewRecorder()
+	server.handleSMSSettings(get, httptest.NewRequest(http.MethodGet, "/api/settings/sms", nil))
+	if get.Code != http.StatusOK || !strings.Contains(get.Body.String(), `"auto_clear_modem_storage":true`) {
+		t.Fatalf("default GET = %d %s", get.Code, get.Body.String())
+	}
+	put := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPut, "/api/settings/sms", strings.NewReader(`{"auto_clear_modem_storage":false}`))
+	request.Header.Set("Content-Type", "application/json")
+	server.handleSMSSettings(put, request)
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, body=%s", put.Code, put.Body.String())
+	}
+	if developer.AutoClearModemStorage(ctx, database) {
+		t.Fatal("auto-clear should be disabled after PUT")
 	}
 }
 

--- a/internal/server/sms_api_test.go
+++ b/internal/server/sms_api_test.go
@@ -559,6 +559,99 @@ func TestSyncModemSMSDoesNotClearUnpersistedMessages(t *testing.T) {
 	}
 }
 
+func TestSyncModemSMSKeepsUnmatchedDeliveryReports(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	const (
+		deviceID = "ec20-1"
+		imei     = "867394042309830"
+	)
+	if err := database.UpsertDevice(ctx, store.Device{
+		ID: deviceID, Name: "EC20", DeviceType: store.DeviceTypePCIeEC20EC25,
+		ModemIMEI: imei, SMSEnabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	reference := 42
+	status := 0
+	controller := &smsDeletionController{
+		fakeDeviceController: fakeDeviceController{entry: device.Device{
+			ID: deviceID, Discovered: true,
+			Snapshot: &device.Snapshot{DeviceID: deviceID, IMEI: imei, IMSI: "23433"},
+		}},
+		storedMessages: []device.SMSMessage{{
+			Index: 8, Storage: "ME", StorageStatus: device.SMSStatusReceivedUnread,
+			Direction: device.SMSDirectionStatusReport, To: "+447700900123",
+			MessageReference: &reference, StatusCode: &status, DeliveryStatus: "delivered",
+			Encoding: device.SMSEncodingGSM7PDU, RawPDU: "report-unmatched",
+		}},
+	}
+	server := &Server{store: database, logger: regionTestLogger(), devices: controller}
+	server.syncModemSMS(ctx, deviceID)
+	controller.mu.Lock()
+	remaining := len(controller.storedMessages)
+	deleted := len(controller.deleted)
+	controller.mu.Unlock()
+	if remaining != 1 || deleted != 0 {
+		t.Fatalf("remaining = %d, deleted = %d", remaining, deleted)
+	}
+}
+
+func TestSyncModemSMSClearsMatchedDeliveryReports(t *testing.T) {
+	ctx := context.Background()
+	database, err := store.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	const (
+		deviceID = "ec20-1"
+		imei     = "867394042309830"
+		imsi     = "23433"
+		peer     = "+447700900123"
+	)
+	if err := database.UpsertDevice(ctx, store.Device{
+		ID: deviceID, Name: "EC20", DeviceType: store.DeviceTypePCIeEC20EC25,
+		ModemIMEI: imei, SMSEnabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.SaveSMSMessage(ctx, store.SMSMessage{
+		MessageID: "outbound-1", DeviceID: deviceID, ModemIMEI: imei, IMSI: imsi,
+		Peer: peer, Direction: "outbound", Body: "ping", Source: "cellular_at",
+		Timestamp: time.Unix(1_700_000_000, 0).UTC(), Extra: json.RawMessage(`{"message_reference":42}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	reference := 42
+	status := 0
+	controller := &smsDeletionController{
+		fakeDeviceController: fakeDeviceController{entry: device.Device{
+			ID: deviceID, Discovered: true,
+			Snapshot: &device.Snapshot{DeviceID: deviceID, IMEI: imei, IMSI: imsi},
+		}},
+		storedMessages: []device.SMSMessage{{
+			Index: 8, Storage: "ME", StorageStatus: device.SMSStatusReceivedUnread,
+			Direction: device.SMSDirectionStatusReport, To: peer,
+			MessageReference: &reference, StatusCode: &status, DeliveryStatus: "delivered",
+			Encoding: device.SMSEncodingGSM7PDU, RawPDU: "report-matched",
+		}},
+	}
+	server := &Server{store: database, logger: regionTestLogger(), devices: controller}
+	server.syncModemSMS(ctx, deviceID)
+	controller.mu.Lock()
+	remaining := len(controller.storedMessages)
+	deleted := append([]string(nil), controller.deleted...)
+	controller.mu.Unlock()
+	if remaining != 0 || strings.Join(deleted, ",") != "ME:8" {
+		t.Fatalf("remaining = %d, deleted = %v", remaining, deleted)
+	}
+}
+
 func TestSMSSettingsAPITogglesAutoClear(t *testing.T) {
 	ctx := context.Background()
 	database, err := store.Open(ctx, ":memory:")

--- a/web/src/components/devices/OverviewSimPanel.tsx
+++ b/web/src/components/devices/OverviewSimPanel.tsx
@@ -3,7 +3,9 @@ import { Button } from "../ui";
 import { FieldRow } from "./FieldRow";
 import { useShowSensitive } from "./shared";
 import type { DeviceDetail } from "./types";
+import type { SMSStorageArea } from "../../types";
 import { useI18n } from "../../lib/i18n";
+import { cx } from "../../lib/utils";
 import { carrierIso } from "../../lib/carrier";
 import { CountryFlag } from "../CountryFlag";
 
@@ -26,6 +28,8 @@ export function OverviewSimPanel({ device, simOperatorDisplay, customPhoneNumber
   const displayedPhoneNumber = customPhoneNumber?.trim() || device.localPhone || "--";
   const backendLabel =
     device.backendMode === "qmi" ? "QMI" : device.backendMode === "mbim" ? "MBIM" : device.backendMode === "at" ? "AT" : "Auto";
+  const storage = device.smsStorage;
+  const storageFull = storageAreaFull(storage?.me) || storageAreaFull(storage?.sm);
 
   return (
     <div className="ui-panel-muted relative min-w-0 overflow-hidden p-4">
@@ -64,7 +68,47 @@ export function OverviewSimPanel({ device, simOperatorDisplay, customPhoneNumber
           <span>{flightOn ? t("是") : t("否")}</span>
         </div>
         <FieldRow label={t("运行模式")} value={backendLabel} monospace />
+        <SMSStorageRow label="ME" area={storage?.me} warningLabel={t("模组短信存储已满，新短信可能无法接收")} />
+        <SMSStorageRow label="SM" area={storage?.sm} warningLabel={t("SIM 短信存储已满，新短信可能无法接收")} />
+        {storageFull ? (
+          <div className="pt-1 text-xs leading-5 text-amber-600 dark:text-amber-400">
+            {t("模组短信存储已满，新短信可能无法接收")}
+          </div>
+        ) : null}
       </div>
+    </div>
+  );
+}
+
+function storageAreaFull(area?: SMSStorageArea) {
+  const used = area?.used ?? 0;
+  const total = area?.total ?? 0;
+  if (total <= 0) return false;
+  return used >= total || used / total >= 0.9;
+}
+
+function SMSStorageRow({
+  label,
+  area,
+  warningLabel,
+}: {
+  label: string;
+  area?: SMSStorageArea;
+  warningLabel: string;
+}) {
+  const total = area?.total ?? 0;
+  if (total <= 0) return null;
+  const used = area?.used ?? 0;
+  const full = storageAreaFull(area);
+  return (
+    <div className="flex justify-between gap-3">
+      <span className="text-gray-500">{label}</span>
+      <span
+        className={cx("font-mono", full && "text-amber-600 dark:text-amber-400")}
+        title={full ? warningLabel : undefined}
+      >
+        {used}/{total}
+      </span>
     </div>
   );
 }

--- a/web/src/components/devices/OverviewSimPanel.tsx
+++ b/web/src/components/devices/OverviewSimPanel.tsx
@@ -29,7 +29,15 @@ export function OverviewSimPanel({ device, simOperatorDisplay, customPhoneNumber
   const backendLabel =
     device.backendMode === "qmi" ? "QMI" : device.backendMode === "mbim" ? "MBIM" : device.backendMode === "at" ? "AT" : "Auto";
   const storage = device.smsStorage;
-  const storageFull = storageAreaFull(storage?.me) || storageAreaFull(storage?.sm);
+  const meFull = storageAreaFull(storage?.me);
+  const smFull = storageAreaFull(storage?.sm);
+  const storageWarning = meFull && smFull
+    ? t("模组和 SIM 短信存储已满，新短信可能无法接收")
+    : smFull
+      ? t("SIM 短信存储已满，新短信可能无法接收")
+      : meFull
+        ? t("模组短信存储已满，新短信可能无法接收")
+        : "";
 
   return (
     <div className="ui-panel-muted relative min-w-0 overflow-hidden p-4">
@@ -70,9 +78,9 @@ export function OverviewSimPanel({ device, simOperatorDisplay, customPhoneNumber
         <FieldRow label={t("运行模式")} value={backendLabel} monospace />
         <SMSStorageRow label="ME" area={storage?.me} warningLabel={t("模组短信存储已满，新短信可能无法接收")} />
         <SMSStorageRow label="SM" area={storage?.sm} warningLabel={t("SIM 短信存储已满，新短信可能无法接收")} />
-        {storageFull ? (
+        {storageWarning ? (
           <div className="pt-1 text-xs leading-5 text-amber-600 dark:text-amber-400">
-            {t("模组短信存储已满，新短信可能无法接收")}
+            {storageWarning}
           </div>
         ) : null}
       </div>

--- a/web/src/components/settings/SMSAutoClearCard.tsx
+++ b/web/src/components/settings/SMSAutoClearCard.tsx
@@ -1,0 +1,38 @@
+import { MailRegular } from "@fluentui/react-icons";
+import { useI18n } from "../../lib/i18n";
+import { Switch } from "../ui/Switch";
+import { CardDecor, CardIcon, CardTitle } from "./Cards";
+
+export function SMSAutoClearCard({
+  enabled,
+  loading,
+  saving,
+  onToggle,
+}: {
+  enabled: boolean;
+  loading: boolean;
+  saving: boolean;
+  onToggle: (enabled: boolean) => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <div className="ui-card group relative overflow-hidden p-8">
+      <CardDecor />
+      <div className="relative z-10 mb-6 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <CardIcon>
+            <MailRegular className="text-[24px]" />
+          </CardIcon>
+          <CardTitle
+            title={t("自动清理模组短信存储")}
+            subtitle={t("入库成功后删除模组 SM/ME 副本，网页记录保留")}
+          />
+        </div>
+        <Switch checked={enabled} disabled={loading || saving} loading={saving} onChange={onToggle} />
+      </div>
+      <p className="relative z-10 text-xs leading-5 text-gray-500 dark:text-gray-400">
+        {t("模组 ME 存储通常只有二十多格。关闭后 VoCat 仍会同步到数据库，但不再删除模组原件，存满后可能收不到新短信。")}
+      </p>
+    </div>
+  );
+}

--- a/web/src/lib/i18n-en.ts
+++ b/web/src/lib/i18n-en.ts
@@ -1259,4 +1259,15 @@ export const EN_DICT: Record<string, string> = {
   "VoLTE 可用": "VoLTE available",
   "VoLTE 未就绪": "VoLTE not ready",
   "设备离线，无法读取或修改模组 IMS 配置。": "The device is offline; its modem IMS configuration cannot be read or changed.",
+  "自动清理模组短信存储": "Auto-clear modem SMS storage",
+  "入库成功后删除模组 SM/ME 副本，网页记录保留":
+    "Delete the modem SM/ME copy after VoCat saves the message; the web inbox is kept",
+  "模组 ME 存储通常只有二十多格。关闭后 VoCat 仍会同步到数据库，但不再删除模组原件，存满后可能收不到新短信。":
+    "Modem ME storage is often only about twenty slots. Turning this off still syncs into the database but leaves the modem copies, so a full mailbox can block new SMS.",
+  "短信存储设置加载失败": "Failed to load SMS storage settings",
+  "短信存储设置保存失败": "Failed to save SMS storage settings",
+  "已开启模组短信自动清理": "Modem SMS auto-clear is on",
+  "已关闭模组短信自动清理": "Modem SMS auto-clear is off",
+  "模组短信存储已满，新短信可能无法接收": "Modem SMS storage is full; new messages may not be received",
+  "SIM 短信存储已满，新短信可能无法接收": "SIM SMS storage is full; new messages may not be received",
 };

--- a/web/src/lib/i18n-en.ts
+++ b/web/src/lib/i18n-en.ts
@@ -1270,4 +1270,5 @@ export const EN_DICT: Record<string, string> = {
   "已关闭模组短信自动清理": "Modem SMS auto-clear is off",
   "模组短信存储已满，新短信可能无法接收": "Modem SMS storage is full; new messages may not be received",
   "SIM 短信存储已满，新短信可能无法接收": "SIM SMS storage is full; new messages may not be received",
+  "模组和 SIM 短信存储已满，新短信可能无法接收": "Modem and SIM SMS storage are full; new messages may not be received",
 };

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { AlertRegular, CheckmarkRegular } from "@fluentui/react-icons";
 import { api, apiMessage, getSecuritySettings, updateSecuritySettings } from "../api";
-import type { DeveloperSettings, HTTPSSettings, NotificationSettings, SecuritySettings, SystemInfo } from "../types";
+import type { DeveloperSettings, HTTPSSettings, NotificationSettings, SecuritySettings, SMSSettings, SystemInfo } from "../types";
 import { Button, PageHeader, confirmDialog, message } from "../components/ui";
 import { CardDecor, CardIcon, CardTitle, SecurityCard, SystemInfoCard } from "../components/settings/Cards";
 import type { PasswordForm, UpdateInfo } from "../components/settings/Cards";
@@ -27,6 +27,7 @@ import { PluginsCard } from "../components/settings/PluginsCard";
 import { HTTPSCard } from "../components/settings/HTTPSCard";
 import { DeviceQuotaCard } from "../components/settings/DeviceQuotaCard";
 import { SMSRateLimitCard } from "../components/settings/SMSRateLimitCard";
+import { SMSAutoClearCard } from "../components/settings/SMSAutoClearCard";
 
 const EMPTY_PASSWORD: PasswordForm = { oldPassword: "", newPassword: "", confirmPassword: "" };
 
@@ -75,6 +76,9 @@ export default function SettingsPage() {
   const [loadingDeveloper, setLoadingDeveloper] = useState(false);
   const [savingDeveloper, setSavingDeveloper] = useState(false);
   const [savingSMSLimit, setSavingSMSLimit] = useState(false);
+  const [smsAutoClear, setSMSAutoClear] = useState(true);
+  const [loadingSMSSettings, setLoadingSMSSettings] = useState(false);
+  const [savingSMSSettings, setSavingSMSSettings] = useState(false);
 
   const updateChannel = useCallback(<K extends keyof NotifyForms>(key: K, patch: Partial<NotifyForms[K]>) => {
     setForms((prev) => ({ ...prev, [key]: { ...prev[key], ...patch } }));
@@ -110,6 +114,18 @@ export default function SettingsPage() {
     setClientIp(data.clientIp ?? "");
     setClientAllowed(!!data.clientAllowed);
   }, []);
+
+  const fetchSMSSettings = useCallback(async () => {
+    setLoadingSMSSettings(true);
+    try {
+      const data = await api<SMSSettings>("/settings/sms");
+      setSMSAutoClear(data.autoClearModemStorage !== false);
+    } catch {
+      message.error(t("短信存储设置加载失败"));
+    } finally {
+      setLoadingSMSSettings(false);
+    }
+  }, [t]);
 
   const fetchSecurity = useCallback(async () => {
     setLoadingSecurity(true);
@@ -151,7 +167,8 @@ export default function SettingsPage() {
     void fetchSystemInfo();
     void fetchNotifications();
     void fetchSecurity();
-  }, [fetchSystemInfo, fetchNotifications, fetchSecurity]);
+    void fetchSMSSettings();
+  }, [fetchSystemInfo, fetchNotifications, fetchSecurity, fetchSMSSettings]);
 
   useEffect(() => {
     if (systemInfo.developer) {
@@ -216,6 +233,19 @@ export default function SettingsPage() {
       setSavingSMSLimit(false);
     }
   }, [developerSettings, smsHourlyLimit, lang]);
+
+  const onToggleSMSAutoClear = useCallback(async (enabled: boolean) => {
+    setSavingSMSSettings(true);
+    try {
+      const data = await api<SMSSettings>("/settings/sms", { method: "PUT", body: { autoClearModemStorage: enabled } });
+      setSMSAutoClear(data.autoClearModemStorage !== false);
+      message.success(enabled ? t("已开启模组短信自动清理") : t("已关闭模组短信自动清理"));
+    } catch (error) {
+      message.error(apiMessage(error) || t("短信存储设置保存失败"));
+    } finally {
+      setSavingSMSSettings(false);
+    }
+  }, [t]);
 
   const onSaveSecurity = useCallback(async () => {
     setSavingSecurity(true);
@@ -448,6 +478,12 @@ export default function SettingsPage() {
           saving={savingSecurity}
           onChange={(patch) => setSecurity((prev) => ({ ...prev, ...patch }))}
           onSave={onSaveSecurity}
+        />
+        <SMSAutoClearCard
+          enabled={smsAutoClear}
+          loading={loadingSMSSettings}
+          saving={savingSMSSettings}
+          onToggle={onToggleSMSAutoClear}
         />
 
         {systemInfo.developer ? (

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -102,6 +102,20 @@ export interface PublicIPInfo {
   organization?: string;
 }
 
+export interface SMSStorageArea {
+  used?: number;
+  total?: number;
+}
+
+export interface SMSStorageUsage {
+  sm?: SMSStorageArea;
+  me?: SMSStorageArea;
+}
+
+export interface SMSSettings {
+  autoClearModemStorage: boolean;
+}
+
 export interface DeviceListItem {
   id: string;
   name: string;
@@ -120,6 +134,7 @@ export interface DeviceListItem {
   interface: string;
   esimTransport: string;
   smsEnabled: boolean;
+  smsStorage?: SMSStorageUsage;
 	  networkEnabled: boolean;
   vowifiEnabled: boolean;
   vowifiActive?: boolean;
@@ -481,6 +496,7 @@ export interface DeveloperSettings {
   smsHourlyLimit: number;
   defaultSmsHourlyLimit: number;
   maxSmsHourlyLimit: number;
+  autoClearModemStorage?: boolean;
 }
 
 export type Notice = {


### PR DESCRIPTION
## Summary
- Fixes https://github.com/MengMengCode/VoCat/issues/125
- After a successful SMS persist, optionally delete the modem SM/ME copy so the ~23-slot ME mailbox does not fill and block new SMS
- Keep VoCat conversation history; add a settings toggle (default on) and ME/SM usage plus a near-full warning on the device overview

## Test plan
- [ ] `go test ./...`
- [ ] Settings page: toggle auto-clear on/off and confirm it persists after reload
- [ ] With auto-clear on: receive SMS, confirm it appears in VoCat, then ME/SM used count drops after sync
- [ ] With auto-clear off: receive SMS, confirm the modem copy remains
- [ ] Overview SIM panel shows `ME used/total` (and SM when available) and a warning when storage is nearly full


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable automatic cleanup of modem SMS after successful synchronization.
  - Added SMS settings controls for enabling or disabling automatic cleanup.
  - Added modem and SIM SMS storage usage details to device views, including near-full warnings.
  - Added SMS storage information to device and settings APIs.
- **Bug Fixes**
  - Prevented notification handling from proceeding when SMS persistence fails.
  - Improved handling of unmatched delivery reports.
- **Tests**
  - Added coverage for SMS storage reporting, cleanup behavior, delivery reports, and settings updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->