### PR TITLE
Fix/ims ipsec mss

### DIFF
--- a/cmd/vocat/main.go
+++ b/cmd/vocat/main.go
@@ -39,6 +39,7 @@ import (
 	"vocat/internal/vowifi/ims"
 	"vocat/internal/vowifi/integration"
 	vowifiruntime "vocat/internal/vowifi/runtime"
+	"vocat/internal/vowifisettings"
 	"vocat/web"
 )
 
@@ -1149,6 +1150,9 @@ func newVoWiFiOrchestrator(
 		return nil, fmt.Errorf("device %q IKE provider: %w", deviceConfig.ID, err)
 	}
 	imsProvider, err := ims.NewProvider(adapter, ims.Config{
+		MTUCompatibility: func(ctx context.Context) bool {
+			return vowifisettings.MTUCompatibility(ctx, database)
+		},
 		Logger: vowifiLogger,
 		// Carrier-specific transport and SMSC defaults live in the shared data
 		// profile. Prefer network-provided P-CSCF hints, then safely try the

--- a/internal/server/settings_api.go
+++ b/internal/server/settings_api.go
@@ -95,6 +95,9 @@ func (s *Server) routeSettingsAPI(
 	case "settings/logging":
 		s.handleLoggingSettings(w, r)
 		return true
+	case "settings/vowifi":
+		s.handleVoWiFiSettings(w, r)
+		return true
 	case "settings/sms":
 		s.handleSMSSettings(w, r)
 		return true

--- a/internal/server/vowifi_settings.go
+++ b/internal/server/vowifi_settings.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"net/http"
+	"vocat/internal/vowifisettings"
+)
+
+func (s *Server) handleVoWiFiSettings(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+	case http.MethodPut:
+		var request struct {
+			MTUCompatibility *bool `json:"mtu_compatibility"`
+		}
+		if err := s.decodeJSON(w, r, &request); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		if request.MTUCompatibility == nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "mtu_compatibility is required")
+			return
+		}
+		if err := vowifisettings.SetMTUCompatibility(r.Context(), s.store, *request.MTUCompatibility); err != nil {
+			s.writeStoreError(w, err)
+			return
+		}
+		s.recordAudit(r.Context(), "admin", "settings.vowifi.mtu_compatibility", "settings", "vowifi", "success", "VoWiFi MTU compatibility updated")
+	default:
+		w.Header().Set("Allow", "GET, PUT")
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": map[string]any{
+		"mtu_compatibility": vowifisettings.MTUCompatibility(r.Context(), s.store),
+	}})
+}

--- a/internal/vowifi/ims/provider.go
+++ b/internal/vowifi/ims/provider.go
@@ -38,10 +38,13 @@ var (
 // LocalAddress is empty, Provider uses the corresponding value proven by the
 // TunnelSession. The default transport is TCP and the default port is 5060.
 type Config struct {
-	PCSCF           string
-	LocalAddress    string
-	Transport       string
-	TransportByPLMN map[string]string
+	// MTUCompatibility opts new protected TCP connections into conservative MSS.
+	// Nil disables it. The callback is evaluated on connection establishment.
+	MTUCompatibility func(context.Context) bool
+	PCSCF            string
+	LocalAddress     string
+	Transport        string
+	TransportByPLMN  map[string]string
 	// AutoTransportFallback tries the alternate TCP/UDP transport only when
 	// the initial P-CSCF attempt produced no SIP response at all. A challenge
 	// or rejection is authoritative and is never retried as another transport.
@@ -559,7 +562,7 @@ func dialSIP(
 	localAddress string,
 	localPort int,
 	remoteAddress string,
-	protected bool,
+	mtuCompatibility bool,
 ) (net.Conn, error) {
 	var local net.Addr
 	var err error
@@ -575,7 +578,7 @@ func dialSIP(
 		return nil, fmt.Errorf("resolve tunnel local address: %w", err)
 	}
 	dialer := net.Dialer{LocalAddr: local}
-	if protected && transport == "tcp" {
+	if mtuCompatibility && transport == "tcp" {
 		configureProtectedTCPDialer(&dialer)
 	}
 	return dialer.DialContext(ctx, transport, remoteAddress)

--- a/internal/vowifi/ims/provider.go
+++ b/internal/vowifi/ims/provider.go
@@ -299,7 +299,7 @@ func (provider *Provider) Start(ctx context.Context, request vowifi.IMSRequest) 
 			transports = append(transports, alternate)
 		}
 		for attempt, candidate := range transports {
-			connection, dialErr := dialSIP(ctx, candidate, localAddress, 0, endpoint.address())
+			connection, dialErr := dialSIP(ctx, candidate, localAddress, 0, endpoint.address(), false)
 			if dialErr != nil {
 				lastErr = fmt.Errorf("ims: connect to P-CSCF over %s: %w", candidate, dialErr)
 				if attempt+1 < len(transports) && ctx.Err() == nil {
@@ -559,6 +559,7 @@ func dialSIP(
 	localAddress string,
 	localPort int,
 	remoteAddress string,
+	protected bool,
 ) (net.Conn, error) {
 	var local net.Addr
 	var err error
@@ -574,6 +575,9 @@ func dialSIP(
 		return nil, fmt.Errorf("resolve tunnel local address: %w", err)
 	}
 	dialer := net.Dialer{LocalAddr: local}
+	if protected && transport == "tcp" {
+		configureProtectedTCPDialer(&dialer)
+	}
 	return dialer.DialContext(ctx, transport, remoteAddress)
 }
 

--- a/internal/vowifi/ims/security.go
+++ b/internal/vowifi/ims/security.go
@@ -868,6 +868,8 @@ func (session *Session) activateIPSec(
 		return fmt.Errorf("%w: installer returned no handle", ErrIPSecInstall)
 	}
 
+	mtuCompatibility := session.provider.config.MTUCompatibility != nil &&
+		session.provider.config.MTUCompatibility(ctx)
 	remoteAddress := net.JoinHostPort(remoteIP.String(), strconv.Itoa(selected.portServer))
 	_ = session.conn.Close()
 	connection, dialErr := dialSIP(
@@ -876,7 +878,7 @@ func (session *Session) activateIPSec(
 		localIP.String(),
 		session.securityProposal.portClient,
 		remoteAddress,
-		true,
+		mtuCompatibility,
 	)
 	if dialErr != nil {
 		cleanupErr := handle.Close(context.Background())

--- a/internal/vowifi/ims/security.go
+++ b/internal/vowifi/ims/security.go
@@ -876,6 +876,7 @@ func (session *Session) activateIPSec(
 		localIP.String(),
 		session.securityProposal.portClient,
 		remoteAddress,
+		true,
 	)
 	if dialErr != nil {
 		cleanupErr := handle.Close(context.Background())

--- a/internal/vowifi/ims/tcp_linux.go
+++ b/internal/vowifi/ims/tcp_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package ims
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Leave room below the IPv6 minimum MTU for TCP and transport-mode ESP,
+// including CBC padding, IV and integrity data. Some older XFRM kernels loop
+// on local Packet Too Big errors instead of shrinking protected TCP segments.
+const protectedTCPMaxSegment = 1100
+
+func configureProtectedTCPDialer(dialer *net.Dialer) {
+	// Apply before connect so both outbound segmentation and the MSS advertised
+	// in the SYN account for ESP overhead. A post-connect change is too late.
+	dialer.Control = func(_, _ string, raw syscall.RawConn) error {
+		var optionErr error
+		if err := raw.Control(func(fd uintptr) {
+			optionErr = unix.SetsockoptInt(int(fd), unix.IPPROTO_TCP, unix.TCP_MAXSEG, protectedTCPMaxSegment)
+		}); err != nil {
+			return fmt.Errorf("ims: access protected TCP socket: %w", err)
+		}
+		if optionErr != nil {
+			return fmt.Errorf("ims: set protected TCP maximum segment size: %w", optionErr)
+		}
+		return nil
+	}
+}

--- a/internal/vowifi/ims/tcp_other.go
+++ b/internal/vowifi/ims/tcp_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package ims
+
+import "net"
+
+func configureProtectedTCPDialer(_ *net.Dialer) {}

--- a/internal/vowifisettings/settings.go
+++ b/internal/vowifisettings/settings.go
@@ -1,0 +1,32 @@
+package vowifisettings
+
+import (
+	"context"
+	"encoding/json"
+	"vocat/internal/store"
+)
+
+const MTUCompatibilityKey = "vowifi.mtu_compatibility"
+
+// MTUCompatibility is opt-in, including for existing installations.
+func MTUCompatibility(ctx context.Context, database *store.Store) bool {
+	if database == nil {
+		return false
+	}
+	setting, err := database.AppSetting(ctx, MTUCompatibilityKey)
+	if err != nil {
+		return false
+	}
+	var value struct {
+		Enabled bool `json:"enabled"`
+	}
+	return json.Unmarshal(setting.Value, &value) == nil && value.Enabled
+}
+
+func SetMTUCompatibility(ctx context.Context, database *store.Store, enabled bool) error {
+	value, err := json.Marshal(map[string]bool{"enabled": enabled})
+	if err != nil {
+		return err
+	}
+	return database.UpsertAppSetting(ctx, store.AppSetting{Key: MTUCompatibilityKey, Value: value})
+}

--- a/web/src/components/settings/VoWiFiMTUCard.tsx
+++ b/web/src/components/settings/VoWiFiMTUCard.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { SettingsRegular } from "@fluentui/react-icons";
+import { api, apiMessage } from "../../api";
+import { useI18n } from "../../lib/i18n";
+import { message } from "../ui";
+import { Switch } from "../ui/Switch";
+import { CardDecor, CardIcon, CardTitle } from "./Cards";
+
+interface VoWiFiSettings { mtuCompatibility: boolean }
+
+export function VoWiFiMTUCard() {
+  const { t } = useI18n();
+  const [enabled, setEnabled] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  useEffect(() => {
+    let active = true;
+    api<VoWiFiSettings>("/settings/vowifi").then((data) => {
+      if (active) { setEnabled(data.mtuCompatibility === true); setLoaded(true); }
+    }).catch(() => { if (active) message.error(t("VoWiFi 兼容设置加载失败")); });
+    return () => { active = false; };
+  }, [t]);
+  const onToggle = async (value: boolean) => {
+    setSaving(true);
+    try {
+      const data = await api<VoWiFiSettings>("/settings/vowifi", {
+        method: "PUT", body: { mtuCompatibility: value },
+      });
+      setEnabled(data.mtuCompatibility === true);
+      message.success(t("设置已保存，请重连 VoWiFi 后生效"));
+    } catch (error) {
+      message.error(apiMessage(error) || t("VoWiFi 兼容设置保存失败"));
+    } finally { setSaving(false); }
+  };
+  return (
+    <div className="ui-card group relative overflow-hidden p-8">
+      <CardDecor />
+      <div className="relative z-10 mb-6 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <CardIcon><SettingsRegular className="text-[24px]" /></CardIcon>
+          <CardTitle title={t("VoWiFi MTU 兼容模式")} subtitle={t("改善部分系统因网络包大小限制导致的注册失败")} />
+        </div>
+        <Switch checked={enabled} disabled={!loaded || saving} loading={saving} onChange={onToggle} />
+      </div>
+      <p className="relative z-10 text-xs leading-5 text-gray-500 dark:text-gray-400">
+        {t("默认关闭。遇到 MTU 不足导致的 VoWiFi 连接问题时可尝试开启。此设置适用于所有设备，保存后请重连 VoWiFi。")}
+      </p>
+    </div>
+  );
+}

--- a/web/src/lib/i18n-en.ts
+++ b/web/src/lib/i18n-en.ts
@@ -5,6 +5,12 @@
  * 富文本片段（嵌套链接/代码块的说明框）不走字典，在组件里按语言分支渲染。
  */
 export const EN_DICT: Record<string, string> = {
+  "VoWiFi MTU 兼容模式": "VoWiFi MTU compatibility mode",
+  "改善部分系统因网络包大小限制导致的注册失败": "Help resolve registration failures caused by packet size limits on some systems",
+  "默认关闭。遇到 MTU 不足导致的 VoWiFi 连接问题时可尝试开启。此设置适用于所有设备，保存后请重连 VoWiFi。": "Off by default. Try enabling this if MTU limits cause VoWiFi connection problems. Applies to all devices; reconnect VoWiFi after saving.",
+  "VoWiFi 兼容设置加载失败": "Failed to load VoWiFi compatibility settings",
+  "VoWiFi 兼容设置保存失败": "Failed to save VoWiFi compatibility settings",
+  "设置已保存，请重连 VoWiFi 后生效": "Settings saved. Reconnect VoWiFi to apply.",
 	"未知设备": "Unknown device",
 	"系统已发现 USB 读卡器，但 PC/SC 服务未运行；请安装并启动 pcscd 后重新扫描。": "The USB card reader was found, but the PC/SC service is not running. Install and start pcscd, then scan again.",
 	"系统已发现 USB 读卡器，但 PC/SC 驱动未加载；请安装 libccid 或厂商驱动后重新扫描。": "The USB card reader was found, but its PC/SC driver is not loaded. Install libccid or the vendor driver, then scan again.",

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -29,6 +29,8 @@ import { DeviceQuotaCard } from "../components/settings/DeviceQuotaCard";
 import { SMSRateLimitCard } from "../components/settings/SMSRateLimitCard";
 import { SMSAutoClearCard } from "../components/settings/SMSAutoClearCard";
 
+import { VoWiFiMTUCard } from "../components/settings/VoWiFiMTUCard";
+
 const EMPTY_PASSWORD: PasswordForm = { oldPassword: "", newPassword: "", confirmPassword: "" };
 
 const NOTIFY_TABS = [
@@ -479,6 +481,7 @@ export default function SettingsPage() {
           onChange={(patch) => setSecurity((prev) => ({ ...prev, ...patch }))}
           onSave={onSaveSecurity}
         />
+        <VoWiFiMTUCard />
         <SMSAutoClearCard
           enabled={smsAutoClear}
           loading={loadingSMSSettings}


### PR DESCRIPTION
410棒子刷debian后，在通过代理连接vowifi时，会由于MTU的问题导致无法建立连接
diff修改此问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a VoWiFi MTU compatibility setting to the Settings page.
  - Users can enable or disable the setting with a switch, with loading, success, and error feedback.
  - Added guidance to reconnect after saving changes.
  - Added support for retrieving and updating the setting through the settings service.
- **Platform Support**
  - Added platform-specific handling for configuring protected VoWiFi TCP connections on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->